### PR TITLE
Use a single alpine image across different Dockerfiles

### DIFF
--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gliderlabs/alpine:3.4
+FROM alpine:3.4
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
 # Set the minimum Docker API version required for libnetwork.

--- a/calicoctl/Dockerfile.calicoctl
+++ b/calicoctl/Dockerfile.calicoctl
@@ -1,4 +1,4 @@
-FROM jeanblanchard/alpine-glibc
+FROM alpine:3.4
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
 ADD dist/calicoctl ./calicoctl

--- a/workload/Dockerfile
+++ b/workload/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 RUN apk add --no-cache \
     python \
     netcat-openbsd


### PR DESCRIPTION
Use a single alpine image, pinned to version 3.4 (the latest release)