### PR TITLE
[WIP] Perform IPIP only off host subnet

### DIFF
--- a/calico_node/allocate-ipip-addr.py
+++ b/calico_node/allocate-ipip-addr.py
@@ -22,7 +22,7 @@ def main():
 	    # No IPIP pools, clean up any old address.
 	    _remove_host_tunnel_addr()
 
-hostname = os.getenv("HOSTNAME")
+hostname = os.getenv("NODENAME")
 client = IPAMClient()
 
 if __name__ == "__main__":

--- a/calico_node/filesystem/etc/calico/confd/templates/bird.cfg.mesh.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird.cfg.mesh.template
@@ -2,11 +2,12 @@
 include "bird_aggr.cfg";
 include "custom_filters.cfg";
 include "bird_ipam.cfg";
+{{$node_ip_key := printf "/host/%s/ip_addr_v4" (getenv "NODENAME")}}{{$node_ip := getv $node_ip_key}}
 
-router id {{getenv "IP"}};
+router id {{$node_ip}};
 
 {{define "LOGGING"}}
-{{$node_logging_key := printf "/host/%s/loglevel" (getenv "HOSTNAME")}}{{if exists $node_logging_key}}{{$logging := getv $node_logging_key}}
+{{$node_logging_key := printf "/host/%s/loglevel" (getenv "NODENAME")}}{{if exists $node_logging_key}}{{$logging := getv $node_logging_key}}
 {{if eq $logging "debug"}}  debug all;{{else if ne $logging "none"}}  debug { states };{{end}}
 {{else if exists "/global/loglevel"}}{{$logging := getv "/global/loglevel"}}
 {{if eq $logging "debug"}}  debug all;{{else if ne $logging "none"}}  debug { states };{{end}}
@@ -39,7 +40,7 @@ protocol direct {
   interface -"cali*", "*"; # Exclude cali* but include everything else.
 }
 
-{{$node_as_key := printf "/host/%s/as_num" (getenv "HOSTNAME")}}
+{{$node_as_key := printf "/host/%s/as_num" (getenv "NODENAME")}}
 # Template for all BGP clients
 template bgp bgp_template {
   {{template "LOGGING"}}
@@ -52,7 +53,7 @@ template bgp bgp_template {
   export filter calico_pools;  # Only want to export routes for workloads.
   next hop self;     # Disable next hop processing and always advertise our
                      # local address as nexthop
-  source address {{getenv "IP"}};  # The local address we use for the TCP connection
+  source address {{$node_ip}};  # The local address we use for the TCP connection
   add paths on;
   graceful restart;  # See comment in kernel section about graceful restart.
 }
@@ -64,7 +65,7 @@ template bgp bgp_template {
 {{$onode_ip_key := printf "/host/%s/ip_addr_v4" .}}{{$onode_ip := getv $onode_ip_key}}
 {{$nums := split $onode_ip "."}}{{$id := join $nums "_"}}
 # For peer {{$onode_ip_key}}
-{{if eq $onode_ip (getenv "IP") }}# Skipping ourselves ({{getenv "IP"}})
+{{if eq $onode_ip ($node_ip) }}# Skipping ourselves ({{$node_ip}})
 {{else if ne "" $onode_ip}}protocol bgp Mesh_{{$id}} from bgp_template {
   neighbor {{$onode_ip}} as {{if exists $onode_as_key}}{{getv $onode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
 }{{end}}{{end}}
@@ -86,7 +87,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 
 
 # ------------- Node-specific peers -------------
-{{$node_peers_key := printf "/host/%s/peer_v4" (getenv "HOSTNAME")}}
+{{$node_peers_key := printf "/host/%s/peer_v4" (getenv "NODENAME")}}
 {{if ls $node_peers_key}}
 {{range gets (printf "%s/*" $node_peers_key)}}{{$data := json .Value}}
 {{$nums := split $data.ip "."}}{{$id := join $nums "_"}}

--- a/calico_node/filesystem/etc/calico/confd/templates/bird.cfg.no-mesh.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird.cfg.no-mesh.template
@@ -2,11 +2,12 @@
 include "bird_aggr.cfg";
 include "custom_filters.cfg";
 include "bird_ipam.cfg";
+{{$node_ip_key := printf "/host/%s/ip_addr_v4" (getenv "NODENAME")}}{{$node_ip := getv $node_ip_key}}
 
-router id {{getenv "IP"}};
+router id {{$node_ip}};
 
 {{define "LOGGING"}}
-{{$node_logging_key := printf "/host/%s/loglevel" (getenv "HOSTNAME")}}{{if exists $node_logging_key}}{{$logging := getv $node_logging_key}}
+{{$node_logging_key := printf "/host/%s/loglevel" (getenv "NODENAME")}}{{if exists $node_logging_key}}{{$logging := getv $node_logging_key}}
 {{if eq $logging "debug"}}  debug all;{{else if ne $logging "none"}}  debug { states };{{end}}
 {{else if exists "/global/loglevel"}}{{$logging := getv "/global/loglevel"}}
 {{if eq $logging "debug"}}  debug all;{{else if ne $logging "none"}}  debug { states };{{end}}
@@ -39,7 +40,7 @@ protocol direct {
   interface -"cali*", "*"; # Exclude cali* but include everything else.
 }
 
-{{$node_as_key := printf "/host/%s/as_num" (getenv "HOSTNAME")}}
+{{$node_as_key := printf "/host/%s/as_num" (getenv "NODENAME")}}
 # Template for all BGP clients
 template bgp bgp_template {
   {{template "LOGGING"}}
@@ -52,7 +53,7 @@ template bgp bgp_template {
   export filter calico_pools;  # Only want to export routes for workloads.
   next hop self;     # Disable next hop processing and always advertise our
                      # local address as nexthop
-  source address {{getenv "IP"}};  # The local address we use for the TCP connection
+  source address {{$node_ip}};  # The local address we use for the TCP connection
   add paths on;
   graceful restart;  # See comment in kernel section about graceful restart.
 }
@@ -71,7 +72,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 
 
 # ------------- Node-specific peers -------------
-{{$node_peers_key := printf "/host/%s/peer_v4" (getenv "HOSTNAME")}}
+{{$node_peers_key := printf "/host/%s/peer_v4" (getenv "NODENAME")}}
 {{if ls $node_peers_key}}
 {{range gets (printf "%s/*" $node_peers_key)}}{{$data := json .Value}}
 {{$nums := split $data.ip "."}}{{$id := join $nums "_"}}

--- a/calico_node/filesystem/etc/calico/confd/templates/bird.toml.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird.toml.template
@@ -3,7 +3,7 @@ src = "bird.cfg.{{if (json (getv "/node_mesh")).enabled}}mesh{{else}}no-mesh{{en
 dest = "/etc/calico/confd/config/bird.cfg"
 prefix = "/calico/bgp/v1"
 keys = [
-    {{if (json (getv "/node_mesh")).enabled}}"/host"{{else}}"/host/{{getenv "HOSTNAME"}}"{{end}},
+    {{if (json (getv "/node_mesh")).enabled}}"/host"{{else}}"/host/{{getenv "NODENAME"}}"{{end}},
     "/global"
 ]
 check_cmd = "bird -p -c {{"{{"}}.src{{"}}"}}"

--- a/calico_node/filesystem/etc/calico/confd/templates/bird6.cfg.mesh.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird6.cfg.mesh.template
@@ -2,11 +2,13 @@
 include "bird6_aggr.cfg";
 include "custom_filters6.cfg";
 include "bird6_ipam.cfg";
+{{$node_ip_key := printf "/host/%s/ip_addr_v4" (getenv "NODENAME")}}{{$node_ip := getv $node_ip_key}}
+{{$node_ip6_key := printf "/host/%s/ip_addr_v6" (getenv "NODENAME")}}{{$node_ip6 := getv $node_ip6_key}}
 
-router id {{getenv "IP"}};  # Use IPv4 address since router id is 4 octets, even in MP-BGP
+router id {{$node_ip}};  # Use IPv4 address since router id is 4 octets, even in MP-BGP
 
 {{define "LOGGING"}}
-{{$node_logging_key := printf "/host/%s/loglevel" (getenv "HOSTNAME")}}{{if exists $node_logging_key}}{{$logging := getv $node_logging_key}}
+{{$node_logging_key := printf "/host/%s/loglevel" (getenv "NODENAME")}}{{if exists $node_logging_key}}{{$logging := getv $node_logging_key}}
 {{if eq $logging "debug"}}  debug all;{{else if ne $logging "none"}}  debug { states };{{end}}
 {{else if exists "/global/loglevel"}}{{$logging := getv "/global/loglevel"}}
 {{if eq $logging "debug"}}  debug all;{{else if ne $logging "none"}}  debug { states };{{end}}
@@ -39,8 +41,8 @@ protocol direct {
   interface -"cali*", "*"; # Exclude cali* but include everything else.
 }
 
-{{if eq "" (getenv "IP6")}}# IPv6 disabled on this node.
-{{else}}{{$node_as_key := printf "/host/%s/as_num" (getenv "HOSTNAME")}}
+{{if eq "" ($node_ip6)}}# IPv6 disabled on this node.
+{{else}}{{$node_as_key := printf "/host/%s/as_num" (getenv "NODENAME")}}
 # Template for all BGP clients
 template bgp bgp_template {
   {{template "LOGGING"}}
@@ -53,7 +55,7 @@ template bgp bgp_template {
   export filter calico_pools;  # Only want to export routes for workloads.
   next hop self;     # Disable next hop processing and always advertise our
                      # local address as nexthop
-  source address {{getenv "IP6"}};  # The local address we use for the TCP connection
+  source address {{$node_ip6}};  # The local address we use for the TCP connection
   add paths on;
   graceful restart;  # See comment in kernel section about graceful restart.
 }
@@ -65,7 +67,7 @@ template bgp bgp_template {
 {{$onode_ip_key := printf "/host/%s/ip_addr_v6" .}}{{$onode_ip := getv $onode_ip_key}}
 {{$nums := split $onode_ip ":"}}{{$id := join $nums "_"}}
 # For peer {{$onode_ip_key}}
-{{if eq $onode_ip (getenv "IP6") }}# Skipping ourselves ({{getenv "IP6"}})
+{{if eq $onode_ip ($node_ip6) }}# Skipping ourselves ({{$node_ip6}})
 {{else if eq "" $onode_ip}}# No IPv6 address configured for this node
 {{else}}protocol bgp Mesh_{{$id}} from bgp_template {
   neighbor {{$onode_ip}} as {{if exists $onode_as_key}}{{getv $onode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
@@ -88,7 +90,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 
 
 # ------------- Node-specific peers -------------
-{{$node_peers_key := printf "/host/%s/peer_v6" (getenv "HOSTNAME")}}
+{{$node_peers_key := printf "/host/%s/peer_v6" (getenv "NODENAME")}}
 {{if ls $node_peers_key}}
 {{range gets (printf "%s/*" $node_peers_key)}}{{$data := json .Value}}
 {{$nums := split $data.ip ":"}}{{$id := join $nums "_"}}

--- a/calico_node/filesystem/etc/calico/confd/templates/bird6.cfg.no-mesh.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird6.cfg.no-mesh.template
@@ -2,11 +2,13 @@
 include "bird6_aggr.cfg";
 include "custom_filters6.cfg";
 include "bird6_ipam.cfg";
+{{$node_ip_key := printf "/host/%s/ip_addr_v4" (getenv "NODENAME")}}{{$node_ip := getv $node_ip_key}}
+{{$node_ip6_key := printf "/host/%s/ip_addr_v6" (getenv "NODENAME")}}{{$node_ip6 := getv $node_ip6_key}}
 
-router id {{getenv "IP"}};  # Use IPv4 address since router id is 4 octets, even in MP-BGP
+router id {{$node_ip}};  # Use IPv4 address since router id is 4 octets, even in MP-BGP
 
 {{define "LOGGING"}}
-{{$node_logging_key := printf "/host/%s/loglevel" (getenv "HOSTNAME")}}{{if exists $node_logging_key}}{{$logging := getv $node_logging_key}}
+{{$node_logging_key := printf "/host/%s/loglevel" (getenv "NODENAME")}}{{if exists $node_logging_key}}{{$logging := getv $node_logging_key}}
 {{if eq $logging "debug"}}  debug all;{{else if ne $logging "none"}}  debug { states };{{end}}
 {{else if exists "/global/loglevel"}}{{$logging := getv "/global/loglevel"}}
 {{if eq $logging "debug"}}  debug all;{{else if ne $logging "none"}}  debug { states };{{end}}
@@ -39,8 +41,8 @@ protocol direct {
   interface -"cali*", "*"; # Exclude cali* but include everything else.
 }
 
-{{if eq "" (getenv "IP6")}}# IPv6 disabled on this node.
-{{else}}{{$node_as_key := printf "/host/%s/as_num" (getenv "HOSTNAME")}}
+{{if eq "" ($node_ip6)}}# IPv6 disabled on this node.
+{{else}}{{$node_as_key := printf "/host/%s/as_num" (getenv "NODENAME")}}
 # Template for all BGP clients
 template bgp bgp_template {
   {{template "LOGGING"}}
@@ -53,7 +55,7 @@ template bgp bgp_template {
   export filter calico_pools;  # Only want to export routes for workloads.
   next hop self;     # Disable next hop processing and always advertise our
                      # local address as nexthop
-  source address {{getenv "IP6"}};  # The local address we use for the TCP connection
+  source address {{$node_ip6}};  # The local address we use for the TCP connection
   add paths on;
   graceful restart;  # See comment in kernel section about graceful restart.
 }
@@ -72,7 +74,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 
 
 # ------------- Node-specific peers -------------
-{{$node_peers_key := printf "/host/%s/peer_v6" (getenv "HOSTNAME")}}
+{{$node_peers_key := printf "/host/%s/peer_v6" (getenv "NODENAME")}}
 {{if ls $node_peers_key}}
 {{range gets (printf "%s/*" $node_peers_key)}}{{$data := json .Value}}
 {{$nums := split $data.ip ":"}}{{$id := join $nums "_"}}

--- a/calico_node/filesystem/etc/calico/confd/templates/bird6.toml.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird6.toml.template
@@ -3,7 +3,7 @@ src = "bird6.cfg.{{if (json (getv "/node_mesh")).enabled}}mesh{{else}}no-mesh{{e
 dest = "/etc/calico/confd/config/bird6.cfg"
 prefix = "/calico/bgp/v1"
 keys = [
-    {{if (json (getv "/node_mesh")).enabled}}"/host"{{else}}"/host/{{getenv "HOSTNAME"}}"{{end}},
+    {{if (json (getv "/node_mesh")).enabled}}"/host"{{else}}"/host/{{getenv "NODENAME"}}"{{end}},
     "/global"
 ]
 check_cmd = "bird6 -p -c {{"{{"}}.src{{"}}"}}"

--- a/calico_node/filesystem/etc/calico/confd/templates/bird6_aggr.toml.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird6_aggr.toml.template
@@ -1,7 +1,7 @@
 [template]
 src = "bird_aggr.cfg.template"
 dest = "/etc/calico/confd/config/bird6_aggr.cfg"
-prefix = "/calico/ipam/v2/host/HOSTNAME/ipv6/block"
+prefix = "/calico/ipam/v2/host/NODENAME/ipv6/block"
 keys = [
     "/",
 ]

--- a/calico_node/filesystem/etc/calico/confd/templates/bird_aggr.toml.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird_aggr.toml.template
@@ -1,7 +1,7 @@
 [template]
 src = "bird_aggr.cfg.template"
 dest = "/etc/calico/confd/config/bird_aggr.cfg"
-prefix = "/calico/ipam/v2/host/HOSTNAME/ipv4/block"
+prefix = "/calico/ipam/v2/host/NODENAME/ipv4/block"
 keys = [
     "/",
 ]

--- a/calico_node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird_ipam.cfg.template
@@ -2,7 +2,7 @@
 filter calico_pools {
   calico_aggr();
   custom_filters();
-{{range ls "/pool"}}{{$data := json (getv (printf "/pool/%s" .))}}
+{{range ls "/v1/ipam/v4/pool"}}{{$data := json (getv (printf "/v1/ipam/v4/pool/%s" .))}}
   if ( net ~ {{$data.cidr}} ) then {
     accept;
   }
@@ -10,12 +10,23 @@ filter calico_pools {
   reject;
 }
 
+{{$network_key := printf "/bgp/v1/host/%s/network_v4" (getenv "NODENAME")}}{{$network := getv $network_key}}
 filter calico_ipip {
-{{range ls "/pool"}}{{$data := json (getv (printf "/pool/%s" .))}}{{if $data.ipip}}
+{{range ls "/v1/ipam/v4/pool"}}{{$data := json (getv (printf "/v1/ipam/v4/pool/%s" .))}}
   if ( net ~ {{$data.cidr}} ) then {
+{{if $network}}
+    if ( from ~ {{$network}} ) then
+      krt_tunnel = "";
+    else
+      krt_tunnel = "{{$data.ipip}}";
+
+    accept;
+  }
+{{else}}
     krt_tunnel = "{{$data.ipip}}";
     accept;
   }
 {{end}}{{end}}
   accept;
 }
+

--- a/calico_node/filesystem/etc/calico/confd/templates/bird_ipam.toml.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird_ipam.toml.template
@@ -1,8 +1,9 @@
 [template]
 src = "bird_ipam.cfg.template"
 dest = "/etc/calico/confd/config/bird_ipam.cfg"
-prefix = "/calico/v1/ipam/v4"
+prefix = "/calico"
 keys = [
-    "/pool",
+    "/v1/ipam/v4/pool",
+    "/bgp/v1/host/NODENAME"
 ]
 reload_cmd = "pkill -HUP bird || true"

--- a/calico_node/filesystem/etc/rc.local
+++ b/calico_node/filesystem/etc/rc.local
@@ -1,5 +1,5 @@
-startup-go || exit 1
 startup || exit 1
+startup-go || exit 1
 
 # Source any additional environment that was added by the startup script
 . startup.env
@@ -39,17 +39,15 @@ case "$CALICO_NETWORKING_BACKEND" in
 	;;
     * )
 	# Run BIRD / Confd.
-	mv /etc/service/available/bird  /etc/service/enabled/
-	mv /etc/service/available/bird6 /etc/service/enabled/
-	mv /etc/service/available/confd /etc/service/enabled/
-
+    #
 	# Run Confd in onetime mode, to ensure that we have a working config in place to allow bird(s) and
 	# felix to start.  Don't fail startup if this confd execution fails.
 	#
 	# First generate the BIRD aggregation TOML file from the template by
-	# switching out the hostname.
-	sed "s/HOSTNAME/$HOSTNAME/" /etc/calico/confd/templates/bird_aggr.toml.template > /etc/calico/confd/conf.d/bird_aggr.toml
-	sed "s/HOSTNAME/$HOSTNAME/" /etc/calico/confd/templates/bird6_aggr.toml.template > /etc/calico/confd/conf.d/bird6_aggr.toml
+	# switching out the nodename.
+	sed "s/NODENAME/$NODENAME/" /etc/calico/confd/templates/bird6_aggr.toml.template > /etc/calico/confd/conf.d/bird6_aggr.toml
+	sed "s/NODENAME/$NODENAME/" /etc/calico/confd/templates/bird_aggr.toml.template > /etc/calico/confd/conf.d/bird_aggr.toml
+	sed "s/NODENAME/$NODENAME/" /etc/calico/confd/templates/bird_ipam.toml.template > /etc/calico/confd/conf.d/bird_ipam.toml
 
 	# Run confd twice.  Our confd TOML files are also generated from confd, so
 	# running twice ensures our starting configuration is correct.
@@ -65,6 +63,11 @@ case "$CALICO_NETWORKING_BACKEND" in
 	confd -confdir=/etc/calico/confd -onetime ${ETCD_ENDPOINTS_CONFD} \
 	      -client-key=${ETCD_KEY_FILE} -client-cert=${ETCD_CERT_FILE} \
 	      -client-ca-keys=${ETCD_CA_CERT_FILE} -keep-stage-file >/felix-startup-2.log 2>&1 || true
+
+    # Enable the confd and bird services
+	mv /etc/service/available/bird  /etc/service/enabled/
+	mv /etc/service/available/bird6 /etc/service/enabled/
+	mv /etc/service/available/confd /etc/service/enabled/
 	;;
 esac
 

--- a/calico_node/filesystem/etc/service/available/confd/run
+++ b/calico_node/filesystem/etc/service/available/confd/run
@@ -1,7 +1,5 @@
 #!/bin/sh
 exec 2>&1
-sed "s/HOSTNAME/$HOSTNAME/" /etc/calico/confd/templates/bird_aggr.toml.template > /etc/calico/confd/conf.d/bird_aggr.toml
-sed "s/HOSTNAME/$HOSTNAME/" /etc/calico/confd/templates/bird6_aggr.toml.template > /etc/calico/confd/conf.d/bird6_aggr.toml
 ETCD_NODE=${ETCD_ENDPOINTS:=${ETCD_SCHEME:=http}://${ETCD_AUTHORITY}}
 ETCD_ENDPOINTS_CONFD=`echo "-node=$ETCD_NODE" | sed -e 's/,/ -node=/g'`
 

--- a/calico_node/filesystem/etc/service/available/felix/run
+++ b/calico_node/filesystem/etc/service/available/felix/run
@@ -1,9 +1,9 @@
 #!/bin/sh
 exec 2>&1
-# Felix doesn't understand HOSTNAME, but the container exports it as a common
-# interface. This ensures Felix gets the right hostname.
-if [ ! -z $HOSTNAME ]; then
-    export FELIX_FELIXHOSTNAME=$HOSTNAME
+# Felix doesn't understand NODENAME, but the container exports it as a common
+# interface. This ensures Felix gets the right name for the node.
+if [ ! -z $NODENAME ]; then
+    export FELIX_FELIXHOSTNAME=$NODENAME
 fi
 export FELIX_ETCDADDR=$ETCD_AUTHORITY
 export FELIX_ETCDENDPOINTS=$ETCD_ENDPOINTS

--- a/calico_node/rpm/calico-dockerless-confd.service
+++ b/calico_node/rpm/calico-dockerless-confd.service
@@ -5,8 +5,9 @@ After=calico-dockerless.service
 Before=calico-dockerless-bird.service
 
 [Service]
-ExecStartPre=/usr/bin/bash -c '/usr/bin/sed "s/HOSTNAME/$HOSTNAME/" /etc/calico/confd/templates/bird_aggr.toml.template > /etc/calico/confd/conf.d/bird_aggr.toml'
-ExecStartPre=/usr/bin/bash -c '/usr/bin/sed "s/HOSTNAME/$HOSTNAME/" /etc/calico/confd/templates/bird6_aggr.toml.template > /etc/calico/confd/conf.d/bird6_aggr.toml'
+ExecStartPre=/usr/bin/bash -c '/usr/bin/sed "s/NODENAME/$NODENAME/" /etc/calico/confd/templates/bird_ipam.toml.template > /etc/calico/confd/conf.d/bird_ipam.toml'
+ExecStartPre=/usr/bin/bash -c '/usr/bin/sed "s/NODENAME/$NODENAME/" /etc/calico/confd/templates/bird_aggr.toml.template > /etc/calico/confd/conf.d/bird_aggr.toml'
+ExecStartPre=/usr/bin/bash -c '/usr/bin/sed "s/NODENAME/$NODENAME/" /etc/calico/confd/templates/bird6_aggr.toml.template > /etc/calico/confd/conf.d/bird6_aggr.toml'
 ExecStartPre=/usr/local/bin/confd -confdir=/etc/calico/confd/ -onetime -node $ETCD_AUTHORITY
 ExecStart=/usr/local/bin/confd -confdir=/etc/calico/confd/ -interval=5 -watch -node $ETCD_AUTHORITY
 EnvironmentFile=/etc/calico/calico-environment

--- a/calico_node/startup.go
+++ b/calico_node/startup.go
@@ -16,15 +16,19 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
-
-	"github.com/satori/go.uuid"
+	"io/ioutil"
+	"net/http"
+	"os"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend"
-	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/client"
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/satori/go.uuid"
 )
 
 // main performs startup operations for a node.
@@ -51,10 +55,14 @@ func main() {
 	// Make sure we have a global cluster ID set.
 	log.Info("Ensuring a cluster guid is set")
 	ensureClusterGuid(c)
+
+	// Update the Node resource if necessary.
+	log.Info("Updating node resource")
+	updateNodeResource()
 }
 
 // ensureClusterGuid assigns a cluster GUID if one doesn't exist.
-func ensureClusterGuid(c api.Client) {
+func ensureClusterGuid(c bapi.Client) {
 	guid := hex.EncodeToString(uuid.NewV4().Bytes())
 	_, err := c.Create(&model.KVPair{
 		Key:   model.GlobalConfigKey{Name: "ClusterGUID"},
@@ -62,11 +70,117 @@ func ensureClusterGuid(c api.Client) {
 	})
 	if err != nil {
 		if _, ok := err.(errors.ErrorResourceAlreadyExists); !ok {
-			log.Warnf("Failed to set ClusterGUID: %s", err)
+			log.WithError(err).Warn("Failed to set ClusterGUID")
 			panic(err)
 		}
 		log.Infof("Using previously configured ClusterGUID")
 		return
 	}
 	log.Infof("Assigned ClusterGUID %s", guid)
+}
+
+// Update the current Node resource configuration (if it exists).
+func updateNodeResource() {
+	var c *client.Client
+	var err error
+	var node *api.Node
+	var modified bool
+
+	if cfg, err := client.LoadClientConfig(""); err != nil {
+		panic(fmt.Sprintf("Error loading config: %s", err))
+	} else if c, err = client.New(*cfg); err != nil {
+		panic(fmt.Sprintf("Error creating client: %s", err))
+	}
+
+	// Get the current Node resource configuration.  If it doesn't exist,
+	// initialise it now.
+	nm := api.NodeMetadata{Name: os.Getenv("NODENAME")}
+	if node, err = c.Nodes().Get(nm); err != nil {
+		if _, ok := err.(errors.ErrorResourceDoesNotExist); !ok {
+			panic(fmt.Sprintf("Error contacting datastore: %s", err))
+		} else {
+			log.WithField("Name", nm.Name).Info("Node has not yet been configured")
+			node = &api.Node{Metadata: nm}
+			modified = true
+		}
+	}
+	log.Infof("Current node config: %v", node)
+
+	// Check to see if we are on AWS, and if so get the IPv4 and IPv6
+	// subnets (if they have not yet been configured).
+	if node.Spec.BGP != nil {
+		log.Infof("BGP configuration is specified")
+
+		// OR IF ENV IS SET TO autodiscover
+		needv4 := (node.Spec.BGP.IPv4Address != nil && node.Spec.BGP.IPv4Network == nil)
+		needv6 := (node.Spec.BGP.IPv6Address != nil && node.Spec.BGP.IPv6Network == nil)
+
+		if needv4 || needv6 {
+			v4, v6 := getAWSSubnets()
+			if needv4 && v4 != nil {
+				log.Info("Setting IPv4 network")
+				node.Spec.BGP.IPv4Network = v4
+				modified = true
+			}
+			if needv6 && v6 != nil {
+				log.Info("Setting IPv6 network")
+				node.Spec.BGP.IPv6Network = v6
+				modified = true
+			}
+		}
+	}
+
+	// If the node was modified, then apply the updated config.
+	if modified {
+		log.Info("Updating node config")
+		if _, err = c.Nodes().Apply(node); err != nil {
+			log.WithError(err).Fatal("Unable to update node config")
+		}
+	}
+}
+
+// getAWSVPCNetworks() returns the (IPv4, IPv6) CIDRS (in IPNet form) on an AWS
+// VPC deployment.
+//
+// Returns nil, nil if the deployment is not AWS, or if the metadata service is
+// unavailable.
+func getAWSSubnets() (*net.IPNet, *net.IPNet) {
+	mac, err := getAWSMetadata("mac")
+	if err != nil {
+		log.Info("Unable to query AWS metadata service")
+		return nil, nil
+	}
+	log.WithField("mac", mac).Info("Found MAC from metadata service")
+
+	var ipnetv4, ipnetv6 *net.IPNet
+	if netv4, err := getAWSMetadata("network/interfaces/macs/" + mac + "/subnet-ipv4-cidr-block"); err == nil {
+		if _, ipnetv4, err = net.ParseCIDR(netv4); err != nil {
+			log.WithError(err).Infof("Cannot parse subnet IPv4 CIDR: %s", netv4)
+		}
+	}
+	if netv6, err := getAWSMetadata("network/interfaces/macs/" + mac + "/subnet-ipv6-cidr-block"); err == nil {
+		if _, ipnetv6, err = net.ParseCIDR(netv6); err != nil {
+			log.WithError(err).Infof("Cannot parse subnet IPv6 CIDR: %s", netv6)
+		}
+	}
+
+	log.WithFields(log.Fields{"IPv4Net": ipnetv4, "IPv6Net": ipnetv6}).Info("Found IP subnets")
+	return ipnetv4, ipnetv6
+}
+
+func getAWSMetadata(md string) (string, error) {
+	resp, err := http.Get("http://169.254.169.254/latest/meta-data/" + md)
+	defer resp.Body.Close()
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Received status code %d", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
 }

--- a/calico_node/startup.py
+++ b/calico_node/startup.py
@@ -233,7 +233,6 @@ def main():
         print "Using k8s backend"
         with open('startup.env', 'w') as f:
             f.write("export DATASTORE_TYPE=kubernetes\n")
-            f.write("export HOSTNAME=%s\n" % hostname)
         return
 
     # Check to see if etcd is available.  If not, wait until it is before

--- a/calicoctl/resourcemgr/node.go
+++ b/calicoctl/resourcemgr/node.go
@@ -25,12 +25,14 @@ func init() {
 		api.NewNode(),
 		api.NewNodeList(),
 		[]string{"NAME"},
-		[]string{"NAME", "ASN", "IPV4", "IPV6"},
+		[]string{"NAME", "ASN", "IPV4", "NETV4", "IPV6", "NETV6"},
 		map[string]string{
-			"NAME": "{{.Metadata.Name}}",
-			"ASN":  "{{if .Spec.BGP}}{{if .Spec.BGP.ASNumber}}{{.Spec.BGP.ASNumber}}{{else}}({{config \"asnumber\"}}){{end}}{{end}}",
-			"IPV4": "{{if .Spec.BGP}}{{if .Spec.BGP.IPv4Address}}{{.Spec.BGP.IPv4Address}}{{end}}{{end}}",
-			"IPV6": "{{if .Spec.BGP}}{{if .Spec.BGP.IPv6Address}}{{.Spec.BGP.IPv6Address}}{{end}}{{end}}",
+			"NAME":  "{{.Metadata.Name}}",
+			"ASN":   "{{if .Spec.BGP}}{{if .Spec.BGP.ASNumber}}{{.Spec.BGP.ASNumber}}{{else}}({{config \"asnumber\"}}){{end}}{{end}}",
+			"IPV4":  "{{if .Spec.BGP}}{{if .Spec.BGP.IPv4Address}}{{.Spec.BGP.IPv4Address}}{{end}}{{end}}",
+			"IPV6":  "{{if .Spec.BGP}}{{if .Spec.BGP.IPv6Address}}{{.Spec.BGP.IPv6Address}}{{end}}{{end}}",
+			"NETV4": "{{if .Spec.BGP}}{{if .Spec.BGP.IPv4Network}}{{.Spec.BGP.IPv4Network}}{{end}}{{end}}",
+			"NETV6": "{{if .Spec.BGP}}{{if .Spec.BGP.IPv6Network}}{{.Spec.BGP.IPv6Network}}{{end}}{{end}}",
 		},
 		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
 			r := resource.(api.Node)

--- a/glide.lock
+++ b/glide.lock
@@ -176,7 +176,8 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: f87d39740b5a49891d6ee2646a17326c5e337b20
+  repo: git@github.com:robbrockbank/libcalico-go
+  version: ac3e07e8ab8630f92325aad443ba3395395e52d7
   subpackages:
   - lib/api
   - lib/api/unversioned

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,7 +21,8 @@ import:
   - json
 - package: github.com/projectcalico/go-yaml-wrapper
 - package: github.com/projectcalico/libcalico-go
-  version: v1.0.0-rc6
+  repo: git@github.com:robbrockbank/libcalico-go
+  version: ac3e07e8ab8630f92325aad443ba3395395e52d7
   subpackages:
   - lib/api
   - lib/api/unversioned


### PR DESCRIPTION
This PR adds the ability to selectively use IPIP based on the hosts subnet.
-  If the IP Pool has IPIP enabled, IPIP is only used if the originating router is off subnet
-  IP subnet detection is added to the node startup processing
-  The ps wide format output for the nodes is updated to include the subnets.
-  Remove the use of HOSTNAME within the calico/node since it was deprecated in favor of NODENAME
-  Update confd templates to use the node IP addresses configured in the node resource rather than the ones in the environment variables - this allows a user to modify the node resource IPs and have the changes reflected in the node.