### PR TITLE
Build calico/ctl Docker image with glibc binaries

### DIFF
--- a/calicoctl/Dockerfile.calicoctl
+++ b/calicoctl/Dockerfile.calicoctl
@@ -5,7 +5,15 @@ ADD dist/calicoctl ./calicoctl
 
 ENV CALICO_CTL_CONTAINER=TRUE
 
-# libltdl.so is needed by docker command line tool
-RUN apk add --no-cache libltdl
+# glibc and libltdl are needed by docker command line tool
+ENV GLIBC_VERSION 2.23-r3
+RUN apk add --no-cache libltdl 
+RUN apk add --no-cache --update wget openssl ca-certificates && \
+  wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
+  wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
+  wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk && \
+  apk add glibc-${GLIBC_VERSION}.apk glibc-bin-${GLIBC_VERSION}.apk && \
+  rm -f glibc-${GLIBC_VERSION}.apk glibc-bin-${GLIBC_VERSION}.apk && \
+  apk del openssl ca-certificates
 
 ENTRYPOINT ["./calicoctl"]


### PR DESCRIPTION
Command 'calicoctl node run' requires that Docker
client is available inside container and it needs
glibc.

Closes #1429