### PR TITLE
Modify default log format for container tests

### DIFF
--- a/tests/st/test_base.py
+++ b/tests/st/test_base.py
@@ -28,7 +28,9 @@ from tests.st.utils.utils import (get_ip, ETCD_SCHEME, ETCD_CA, ETCD_CERT,
 HOST_IPV6 = get_ip(v6=True)
 HOST_IPV4 = get_ip()
 
-logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+FORMAT_STRING = '# %(asctime)s [%(levelname)s][%(process)s/%(thread)x] ' \
+               '%(name)s %(lineno)d: %(message)s'
+logging.basicConfig(level=logging.DEBUG, format=FORMAT_STRING)
 logger = logging.getLogger(__name__)
 
 # Disable spammy logging from the sh module


### PR DESCRIPTION
Migrated from https://github.com/projectcalico/libcalico/pull/181


lwr20 commented 11 days ago • edited
Format has been taken from the Felix log formatter (@fasaxc recommended it).

Example output with the new formatter:
```
2017-01-19 12:49:18,801 [INFO][26158/140043457387184] tests.st.utils.utils 73:   # 64 bytes from 192.168.141.192: seq=0 ttl=64 time=0.145 ms
2017-01-19 12:49:18,802 [INFO][26158/140043457387184] tests.st.utils.utils 73:   # 
2017-01-19 12:49:18,803 [INFO][26158/140043457387184] tests.st.utils.utils 73:   # --- 192.168.141.192 ping statistics ---
2017-01-19 12:49:18,803 [INFO][26158/140043457387184] tests.st.utils.utils 73:   # 1 packets transmitted, 1 packets received, 0% packet loss
2017-01-19 12:49:18,804 [INFO][26158/140043457387184] tests.st.utils.utils 73:   # round-trip min/avg/max = 0.145/0.14
```
Timestamp should allow us to do things like profiling tests (seeing where all the time is going).

Comment trail from that:

fasaxc commented 11 days ago
I consider the timestamp, severity and file/line no must-haves. Rest is useful from time to time.
 @tomdee
     Member
tomdee commented 11 days ago
Some of the test output is designed to be copy pastable to repro tests. E.g. some lines start with a hash and some don't. Will this break that?
 @lwr20
     Member
lwr20 commented 11 days ago
@tomdee Ah - now that's exactly the sort of thing I was hoping to find out. Where does that hash get put on?
 @tomdee
     Member
tomdee commented 11 days ago
You should be able to find it by looking at the logging code
 @lwr20
     Member
lwr20 commented 10 days ago • edited
That's not very helpful - there's "logging code" throughout the tests. Ah - I think you're referring to log_and_run() in utils.py.

However, looking at the other various instances of logging around the place, I'm fairly sure that the requirement that the output be cut-and-pastable wasn't understood by authors and reviewers for quite a few PRs now - its clearly been broken for a long time.

Before I spend time fixing them all up, is this still a requirement?
 @fasaxc
     Member
fasaxc commented 10 days ago
@lwr20 Can you just add a # to the start of the log format, then make sure that log_and_run puts a \n\n before the commands it prints?
 @lwr20
     Member
lwr20 commented 10 days ago
Ah - good call. I'll also need to fix up all the places we've broken it in the past, but yeah - maybe that's doable.
lwr20 added some commits 10 days ago
 @lwr20	Put # on the front of logs to allow cut-and-paste repro			3229602
 @lwr20	Remove time formatting, because we want milliseconds			12bcbf5
@lwr20
     Member
lwr20 commented 10 days ago
Hmm. Not sure that's working quite right. Commands are getting timestamped. Let me have a further think...
 @tomdee
     Member
tomdee commented 10 days ago
It's not a requirement. I was just letting you know that it was once a thing.