### PR TITLE
Fix rc.local in calico-node due to docker overlayfs bug when using Ce…

### DIFF
--- a/calico_node/filesystem/etc/rc.local
+++ b/calico_node/filesystem/etc/rc.local
@@ -23,6 +23,10 @@ allocate-ipip-addr || exit 1
 # Create a directly to put enabled service files
 mkdir /etc/service/enabled
 
+# XXX: Here and below we do all manupulations on /etc/service avoiding rm'ing
+# dirs contained in Docker image. This is due to bug in Docker with graphdriver
+# overlay on CentOS 7.X kernels (https://github.com/docker/docker/issues/15314)
+
 # Felix is always enabled
 cp -a /etc/service/available/felix /etc/service/enabled/
 

--- a/calico_node/filesystem/etc/rc.local
+++ b/calico_node/filesystem/etc/rc.local
@@ -20,19 +20,11 @@ startup || exit 1
 # If possible pre-allocate the IP address on the IPIP tunnel.
 allocate-ipip-addr || exit 1
 
-if [ "$CALICO_DISABLE_FILE_LOGGING" == "true" ]; then
-	rm -r /etc/service/available/bird/log
-	rm -r /etc/service/available/bird6/log
-	rm -r /etc/service/available/confd/log
-	rm -r /etc/service/available/felix/log
-	rm -r /etc/service/available/calico-bgp-daemon/log
-fi
-
 # Create a directly to put enabled service files
 mkdir /etc/service/enabled
 
 # Felix is always enabled
-mv /etc/service/available/felix /etc/service/enabled/
+cp -a /etc/service/available/felix /etc/service/enabled/
 
 case "$CALICO_NETWORKING_BACKEND" in
     "none" )
@@ -42,13 +34,13 @@ case "$CALICO_NETWORKING_BACKEND" in
     "gobgp" )
 	# Run calico-bgp-daemon instead of BIRD / Confd.
 	echo "CALICO_NETWORKING_BACKEND is gobgp - run calico-bgp-daemon"
-	mv /etc/service/available/calico-bgp-daemon /etc/service/enabled/
+	cp -a /etc/service/available/calico-bgp-daemon /etc/service/enabled/
 	;;
     * )
 	# Run BIRD / Confd.
-	mv /etc/service/available/bird  /etc/service/enabled/
-	mv /etc/service/available/bird6 /etc/service/enabled/
-	mv /etc/service/available/confd /etc/service/enabled/
+	cp -a /etc/service/available/bird  /etc/service/enabled/
+	cp -a /etc/service/available/bird6 /etc/service/enabled/
+	cp -a /etc/service/available/confd /etc/service/enabled/
 
 	# Run Confd in onetime mode, to ensure that we have a working config in place to allow bird(s) and
 	# felix to start.  Don't fail startup if this confd execution fails.
@@ -75,11 +67,19 @@ case "$CALICO_NETWORKING_BACKEND" in
 	;;
 esac
 
-# If running libnetwork plugin in a separate container, CALICO_LIBNETWORK_ENABLED would be false. 
+# If running libnetwork plugin in a separate container, CALICO_LIBNETWORK_ENABLED would be false.
 # CALICO_LIBNETWORK_ENABLED is "false" by default. It can be set by passing `--libnetwork` flag while starting the calico/node via calicoctl
 if [ "$CALICO_LIBNETWORK_ENABLED" == "true" ]; then
 	echo "CALICO_LIBNETWORK_ENABLED is true - start libnetwork service"
-	mv /etc/service/available/libnetwork  /etc/service/enabled/
+	cp -a /etc/service/available/libnetwork  /etc/service/enabled/
+fi
+
+if [ "$CALICO_DISABLE_FILE_LOGGING" == "true" ]; then
+	rm -r /etc/service/available/bird/log
+	rm -r /etc/service/available/bird6/log
+	rm -r /etc/service/available/confd/log
+	rm -r /etc/service/available/felix/log
+	rm -r /etc/service/available/calico-bgp-daemon/log
 fi
 
 echo "Calico node started successfully"


### PR DESCRIPTION
…ntOS 7 kernels

Due to bug in docker (https://github.com/docker/docker/issues/15314) we cant rmdir
any dirs on underlying layers. Fix it by copying service files first and then rm'ming
log dirs.