### PR TITLE
Tag quay latest after build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,11 @@ endif
 	  echo "Version check passed\n"; \
 	fi
 
-	# Retag images with corect version and quay
+	# Retag images with correct version and quay
 	docker tag $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_NAME):$(VERSION)
 	docker tag $(CTL_CONTAINER_NAME) $(CTL_CONTAINER_NAME):$(VERSION)
 	docker tag $(NODE_CONTAINER_NAME) quay.io/$(NODE_CONTAINER_NAME):$(VERSION)
 	docker tag $(CTL_CONTAINER_NAME) quay.io/$(CTL_CONTAINER_NAME):$(VERSION)
-	docker tag $(NODE_CONTAINER_NAME) quay.io/$(NODE_CONTAINER_NAME):latest
-	docker tag $(CTL_CONTAINER_NAME) quay.io/$(CTL_CONTAINER_NAME):latest
 
 	# Check that images were created recently and that the IDs of the versioned and latest images match
 	@docker images --format "{{.CreatedAt}}\tID:{{.ID}}\t{{.Repository}}:{{.Tag}}" $(NODE_CONTAINER_NAME)

--- a/Makefile.calico-node
+++ b/Makefile.calico-node
@@ -57,7 +57,7 @@ calico_test.created: $(TEST_CONTAINER_FILES)
 calico/node: $(NODE_CONTAINER_CREATED)    ## Create the calico/node image
 
 calico-node.tar: $(NODE_CONTAINER_CREATED)
-	docker save --output $@ $(NODE_CONTAINER_NAME)
+	docker save --output $@ quay.io/$(NODE_CONTAINER_NAME):latest
 
 # Build ACI (the APPC image file format) of calico/node.
 # Requires docker2aci installed on host: https://github.com/appc/docker2aci
@@ -67,6 +67,7 @@ calico-node-latest.aci: calico-node.tar
 # Build calico/node docker image - explicitly depend on the container binaries.
 $(NODE_CONTAINER_CREATED): $(NODE_CONTAINER_DIR)/Dockerfile $(NODE_CONTAINER_FILES) $(addprefix $(NODE_CONTAINER_BIN_DIR)/,$(NODE_CONTAINER_BINARIES))
 	docker build -t $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_DIR)
+	docker tag $(NODE_CONTAINER_NAME) quay.io/$(NODE_CONTAINER_NAME):latest
 	touch $@
 
 # Get felix binaries

--- a/Makefile.calicoctl
+++ b/Makefile.calicoctl
@@ -63,6 +63,7 @@ vendor: glide.yaml
 # build calico_ctl image
 $(CTL_CONTAINER_CREATED): calicoctl/Dockerfile.calicoctl dist/calicoctl
 	docker build -t $(CTL_CONTAINER_NAME) -f calicoctl/Dockerfile.calicoctl .
+	docker tag $(CTL_CONTAINER_NAME) quay.io/$(CTL_CONTAINER_NAME):latest
 	touch $@
 
 ## Build calicoctl


### PR DESCRIPTION
Looks as though the default node image was updated to use quay, but we weren't tagging our calico/node image as quay, nor tarring up the quay image for use with the STs.

Upshot of this is that the STs will be downloading quay.io/calico/node:latest each time we start calico node.  Explains why the STs were taking so damn long.  It might also explain why #1488 is working ... I think that will need to be rebased off this once it is in.