### PR TITLE
Remove quay.io tagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,13 @@ endif
 	  echo "Version check passed\n"; \
 	fi
 
-	# Retag images with correct version and quay
+	# Retag images with corect version and quay
 	docker tag $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_NAME):$(VERSION)
 	docker tag $(CTL_CONTAINER_NAME) $(CTL_CONTAINER_NAME):$(VERSION)
 	docker tag $(NODE_CONTAINER_NAME) quay.io/$(NODE_CONTAINER_NAME):$(VERSION)
 	docker tag $(CTL_CONTAINER_NAME) quay.io/$(CTL_CONTAINER_NAME):$(VERSION)
+	docker tag $(NODE_CONTAINER_NAME) quay.io/$(NODE_CONTAINER_NAME):latest
+	docker tag $(CTL_CONTAINER_NAME) quay.io/$(CTL_CONTAINER_NAME):latest
 
 	# Check that images were created recently and that the IDs of the versioned and latest images match
 	@docker images --format "{{.CreatedAt}}\tID:{{.ID}}\t{{.Repository}}:{{.Tag}}" $(NODE_CONTAINER_NAME)

--- a/Makefile.calico-node
+++ b/Makefile.calico-node
@@ -57,7 +57,7 @@ calico_test.created: $(TEST_CONTAINER_FILES)
 calico/node: $(NODE_CONTAINER_CREATED)    ## Create the calico/node image
 
 calico-node.tar: $(NODE_CONTAINER_CREATED)
-	docker save --output $@ quay.io/$(NODE_CONTAINER_NAME):latest
+	docker save --output $@ $(NODE_CONTAINER_NAME)
 
 # Build ACI (the APPC image file format) of calico/node.
 # Requires docker2aci installed on host: https://github.com/appc/docker2aci
@@ -67,7 +67,6 @@ calico-node-latest.aci: calico-node.tar
 # Build calico/node docker image - explicitly depend on the container binaries.
 $(NODE_CONTAINER_CREATED): $(NODE_CONTAINER_DIR)/Dockerfile $(NODE_CONTAINER_FILES) $(addprefix $(NODE_CONTAINER_BIN_DIR)/,$(NODE_CONTAINER_BINARIES))
 	docker build -t $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_DIR)
-	docker tag $(NODE_CONTAINER_NAME) quay.io/$(NODE_CONTAINER_NAME):latest
 	touch $@
 
 # Get felix binaries

--- a/Makefile.calico-node
+++ b/Makefile.calico-node
@@ -255,6 +255,7 @@ st: dist/calicoctl busybox.tar routereflector.tar calico-node.tar workload.tar r
 	           -e HOST_CHECKOUT_DIR=$(HOST_CHECKOUT_DIR) \
 	           -e DEBUG_FAILURES=$(DEBUG_FAILURES) \
 	           -e MY_IP=$(LOCAL_IP_ENV) \
+                   -e NODE_CONTAINER_NAME=$(NODE_CONTAINER_NAME) \
 	           --rm -ti \
 	           -v /var/run/docker.sock:/var/run/docker.sock \
 	           -v $(SOURCE_DIR):/code \
@@ -282,6 +283,7 @@ st-ssl: run-etcd-ssl dist/calicoctl busybox.tar calico-node.tar routereflector.t
 	           -e HOST_CHECKOUT_DIR=$(HOST_CHECKOUT_DIR) \
 	           -e DEBUG_FAILURES=$(DEBUG_FAILURES) \
 	           -e MY_IP=$(LOCAL_IP_ENV) \
+                   -e NODE_CONTAINER_NAME=$(NODE_CONTAINER_NAME) \
 	           -e ETCD_SCHEME=https \
 	           -e ETCD_CA_CERT_FILE=$(SOURCE_DIR)/certs/ca.pem \
 	           -e ETCD_CERT_FILE=$(SOURCE_DIR)/certs/client.pem \

--- a/Makefile.calicoctl
+++ b/Makefile.calicoctl
@@ -63,7 +63,6 @@ vendor: glide.yaml
 # build calico_ctl image
 $(CTL_CONTAINER_CREATED): calicoctl/Dockerfile.calicoctl dist/calicoctl
 	docker build -t $(CTL_CONTAINER_NAME) -f calicoctl/Dockerfile.calicoctl .
-	docker tag $(CTL_CONTAINER_NAME) quay.io/$(CTL_CONTAINER_NAME):latest
 	touch $@
 
 ## Build calicoctl

--- a/tests/st/utils/docker_host.py
+++ b/tests/st/utils/docker_host.py
@@ -31,6 +31,7 @@ CHECKOUT_DIR = os.getenv("HOST_CHECKOUT_DIR", "")
 if CHECKOUT_DIR == "":
     CHECKOUT_DIR = os.getcwd()
 
+NODE_CONTAINER_NAME = os.getenv("NODE_CONTAINER_NAME", "calico/node:latest")
 
 class DockerHost(object):
     """
@@ -216,7 +217,7 @@ class DockerHost(object):
         Start calico in a container inside a host by calling through to the
         calicoctl node command.
         """
-        args = ['node', 'run']
+        args = ['node', 'run', '--node-image=%s' % NODE_CONTAINER_NAME]
         if self.ip:
             args.append('--ip=%s' % self.ip)
         if self.ip6:
@@ -264,9 +265,9 @@ class DockerHost(object):
                      "-e ETCD_AUTHORITY=%s -e ETCD_SCHEME=%s %s "
                      "-v /var/log/calico:/var/log/calico "
                      "-v /var/run/calico:/var/run/calico "
-                     "calico/node:latest" % (hostname_args,
-                                             self.ip,
-                                             etcd_auth, ETCD_SCHEME, ssl_args))
+                     "%s" % (hostname_args, self.ip, etcd_auth, ETCD_SCHEME,
+                             ssl_args, NODE_CONTAINER_NAME)
+                     )
 
     def remove_workloads(self):
         """


### PR DESCRIPTION
After #1490 was merged you are always forced to tag calico/node and calico/ctl images with quay.io, even if you just build stuff locally and not going to upload it somewhere. That change also may confuse if you   upload calico images to your private registry instead of quay.io or docker hub.

I propose to revert changes from #1490 and add an ability of image name specifying for the system tests.