### PR TITLE
Adding env passthrough

### DIFF
--- a/calicoctl/commands/node/run.go
+++ b/calicoctl/commands/node/run.go
@@ -111,12 +111,10 @@ Options:
                            > interface=<IFACE NAME REGEX>
                              Use the first valid IP address found on interfaces
                              named as per the supplied interface name regex.
-                           [default: first-found]
      --ip6-autodetection-method=<IP6_AUTODETECTION_METHOD>
                            Specify the autodetection method for detecting the
                            local IPv6 routing address for this node.  See
                            ip-autodetection-method flag for valid options.
-                           [default: first-found]
      --log-dir=<LOG_DIR>   The directory containing Calico logs.
                            [default: /var/log/calico]
      --node-image=<DOCKER_IMAGE_NAME>
@@ -216,6 +214,20 @@ Description:
 			ifprefix = env
 		} else {
 			ifprefix = "cali"
+		}
+	}
+	if ipv4ADMethod == "" {
+		if env := os.Getenv("CALICO_IP_AUTODETECTION_METHOD"); env != "" {
+			ipv4ADMethod = env
+		} else {
+			ipv4ADMethod = "first-found"
+		}
+	}
+	if ipv6ADMethod == "" {
+		if env := os.Getenv("CALICO_IP6_AUTODETECTION_METHOD"); env != "" {
+			ipv6ADMethod = env
+		} else {
+			ipv6ADMethod = "first-found"
 		}
 	}
 

--- a/calicoctl/commands/node/run.go
+++ b/calicoctl/commands/node/run.go
@@ -287,14 +287,16 @@ Description:
 	}
 
 	// Add in optional environments.
-	if asNumber != "" {
-		envs["AS"] = asNumber
-	}
-	if ipv4 != "" {
-		envs["IP"] = ipv4
-	}
-	if ipv6 != "" {
-		envs["IP6"] = ipv6
+	if strings.ToLower(backend) != "none" {
+		if asNumber != "" {
+			envs["AS"] = asNumber
+		}
+		if ipv4 != "" {
+			envs["IP"] = ipv4
+		}
+		if ipv6 != "" {
+			envs["IP6"] = ipv6
+		}
 	}
 
 	// Create a struct for volumes to mount.

--- a/tests/st/calicoctl/test_node_run.py
+++ b/tests/st/calicoctl/test_node_run.py
@@ -58,7 +58,7 @@ class TestNodeRun(TestBase):
             self.assertEquals(calico_out, 'dummyVal')
             self.assertEquals(felix_out, 'felixDummyVal')
 
-            # Veryify calico-node started with dummy values
+            # Verify calico-node started with dummy values
             logs = host.execute('docker logs calico-node')
             self.assertIn('Calico node started successfully', logs)
 

--- a/tests/st/calicoctl/test_node_run.py
+++ b/tests/st/calicoctl/test_node_run.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,19 @@
 # limitations under the License.
 from tests.st.test_base import TestBase
 from tests.st.utils.docker_host import DockerHost
+import time
+
+from tests.st.test_base import TestBase
+from tests.st.utils.docker_host import DockerHost
+from tests.st.utils.exceptions import CommandExecError
+from tests.st.utils.utils import retry_until_success
+import os
 
 """
 Test calicoctl node run
 
+The `calicoctl node run` command is tested fairly throughouly by other tests.  Here we
+want to test passing env vars through `calicoctl node run` into the container.
 """
 
 class TestNodeRun(TestBase):
@@ -29,3 +38,48 @@ class TestNodeRun(TestBase):
             assert "ETCD_AUTHORITY" not in output
             assert "ETCD_SCHEME" not in output
             assert "ETCD_ENDPOINTS" in output
+
+
+class TestNodeRun(TestBase):
+    
+    def test_node_run_passes_env_vars(self):
+        """
+        Set some CALICO_ and FELIX_ env vars and see that they make it through to the
+        Node container
+        """
+        env_vars = {'CALICO_TESTVAL': 'dummyVal',
+                    'FELIX_TESTVAL': 'felixDummyVal'}
+
+        with DockerHost('host', dind=False, start_calico=True,
+                        calico_env_vars=env_vars) as host:
+            calico_out = host.execute('docker exec -ti calico-node printenv CALICO_TESTVAL')
+            felix_out = host.execute('docker exec -ti calico-node printenv FELIX_TESTVAL')
+
+            self.assertEquals(calico_out, 'dummyVal')
+            self.assertEquals(felix_out, 'felixDummyVal')
+
+            # Veryify calico-node started with dummy values
+            logs = host.execute('docker logs calico-node')
+            self.assertIn('Calico node started successfully', logs)
+
+    def test_env_vars_are_used(self):
+        """
+        Test that CALICO_ env vars are used when set
+        """
+        env_vars = {'CALICO_NETWORKING_BACKEND': 'none',
+                    'FELIX_LOGSEVERITYSCREEN': 'DEBUG'}
+
+        with DockerHost('host', dind=False, start_calico=True,
+                        calico_env_vars=env_vars) as host:
+            logs = host.execute('docker logs calico-node | grep -i CALICO_NETWORKING_BACKEND')
+
+            self.assertIn(
+                'CALICO_NETWORKING_BACKEND is none - no BGP daemon running',
+                logs)
+
+            def check_logs():
+                felix_logs = host.execute(
+                    'docker exec -it calico-node cat /var/log/calico/felix/current | grep -i LOGSEVERITYSCREEN')
+                self.assertIn('Parsed value for LogSeverityScreen: DEBUG (from environment variable)',
+                              felix_logs)
+            retry_until_success(check_logs, 10)


### PR DESCRIPTION
Adding the ability to pass env vars through `calicoctl node run` that are prefixed with `CALICO_*` or FELIX_*`.

Fixes #1501
Fixes #1597