### PR TITLE
Convert profile tests to individual test methods and fix up.

### DIFF
--- a/tests/st/bgp/test_global_config.py
+++ b/tests/st/bgp/test_global_config.py
@@ -20,6 +20,7 @@ from tests.st.utils.constants import (DEFAULT_IPV4_ADDR_1, DEFAULT_IPV4_ADDR_2,
 from tests.st.utils.exceptions import CommandExecError
 from tests.st.utils.utils import check_bird_status
 
+
 class TestBGP(TestBase):
 
     def test_defaults(self):

--- a/tests/st/ipam/test_ipam.py
+++ b/tests/st/ipam/test_ipam.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 class MultiHostIpam(TestBase):
     @classmethod
     def setUpClass(cls):
-        super(TestBase, cls).setUpClass()
+        super(MultiHostIpam, cls).setUpClass()
         cls.hosts = []
         cls.hosts.append(DockerHost("host1",
                                     additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS,
@@ -52,9 +52,13 @@ class MultiHostIpam(TestBase):
         cls.network.delete()
         for host in cls.hosts:
             host.cleanup()
-            del host
 
+        super(MultiHostIpam, cls).tearDownClass()
+
+    wipe_etcd_before_each_test = False
+    
     def setUp(self):
+        super(MultiHostIpam, self).setUp()
         # Save off original pool if any, then wipe pools so we have a known ground state
         response = self.hosts[0].calicoctl("get IPpool -o yaml")
         self.orig_pools = yaml.safe_load(response)

--- a/tests/st/libnetwork/test_labeling.py
+++ b/tests/st/libnetwork/test_labeling.py
@@ -52,7 +52,7 @@ class TestLibnetworkLabeling(TestBase):
 
     @classmethod
     def setUpClass(cls):
-        wipe_etcd(get_ip())
+        super(TestLibnetworkLabeling, cls).setUpClass()
 
         # Rough idea for setup
         #
@@ -99,9 +99,11 @@ class TestLibnetworkLabeling(TestBase):
                 "workload4", network=cls.network2,
                 labels=["org.projectcalico.label.foo=bar"])
 
+    wipe_etcd_before_each_test = False
+
     def setUp(self):
-        # Override the per-test setUp to avoid wiping etcd; instead only
-        # clean up the data we added.
+        super(TestLibnetworkLabeling, self).setUp()
+        # We disable the automatic wipe of etcd, make sure we clean up what we added.
         self.host1.delete_all_resource("policy")
 
     def tearDown(self):
@@ -115,7 +117,7 @@ class TestLibnetworkLabeling(TestBase):
             host.remove_workloads()
         for host in cls.hosts:
             host.cleanup()
-            del host
+        super(TestLibnetworkLabeling, cls).tearDownClass()
 
     def test_policy_only_selectors_allow_traffic(self):
         self.host1.add_resource([

--- a/tests/st/policy/test_profile.py
+++ b/tests/st/policy/test_profile.py
@@ -14,7 +14,6 @@
 import copy
 import netaddr
 import yaml
-from nose_parameterized import parameterized
 
 from tests.st.test_base import TestBase
 from tests.st.utils.docker_host import DockerHost, CLUSTER_STORE_DOCKER_OPTIONS
@@ -28,198 +27,187 @@ POST_DOCKER_COMMANDS = ["docker load -i /code/calico-node.tar",
 
 
 class MultiHostMainline(TestBase):
-    @parameterized.expand([
-        #"tags",
-        "rules.tags",
-        #"rules.protocol.icmp",
-        #"rules.ip.addr",
-        #"rules.ip.net",
-        #"rules.selector",
-        #"rules.tcp.port",
-        #"rules.udp.port",
-    ])
-    def test_multi_host(self, test_type):
-        """
-        Run a mainline multi-host test.
-        Because multihost tests are slow to setup, this tests most mainline
-        functionality in a single test.
-        - Create two hosts
-        - Create a network using the default IPAM driver, and a workload on
-          each host assigned to that network.
-        - Create a network using the Calico IPAM driver, and a workload on
-          each host assigned to that network.
-        - Check that hosts on the same network can ping each other.
-        - Check that hosts on different networks cannot ping each other.
-        - Modify the profile rules
-        - Check that connectivity has changed to match the profile we set up
-        - Re-apply the original profile
-        - Check that connectivity goes back to what it was originally.
-        """
-        with DockerHost("host1",
-                        additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS,
-                        post_docker_commands=POST_DOCKER_COMMANDS,
-                        start_calico=False) as host1, \
-                DockerHost("host2",
-                           additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS,
-                           post_docker_commands=POST_DOCKER_COMMANDS,
-                           start_calico=False) as host2:
-            (n1_workloads, n2_workloads, networks) = \
-                self._setup_workloads(host1, host2)
+    host1 = None
+    host2 = None
 
-            # Get the original profiles:
-            output = host1.calicoctl("get profile -o yaml")
-            original_profiles = yaml.safe_load(output)
-            # Make a copy of the profiles to mess about with.
-            new_profiles = copy.deepcopy(original_profiles)
+    @classmethod
+    def setUpClass(cls):
+        super(MultiHostMainline, cls).setUpClass()
+        cls.host1 = DockerHost("host1",
+                               additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS,
+                               post_docker_commands=POST_DOCKER_COMMANDS)
+        cls.host2 = DockerHost("host2",
+                               additional_docker_options=CLUSTER_STORE_DOCKER_OPTIONS,
+                               post_docker_commands=POST_DOCKER_COMMANDS)
 
-            if test_type == "tags":
-                profile0_tag = new_profiles[0]['metadata']['tags'][0]
-                profile1_tag = new_profiles[1]['metadata']['tags'][0]
-                # Make a new profiles dict where the two networks have each
-                # other in their tags list
-                new_profiles[0]['metadata']['tags'].append(profile1_tag)
-                new_profiles[1]['metadata']['tags'].append(profile0_tag)
+    @classmethod
+    def tearDownClass(cls):
+        cls.host1.cleanup()
+        cls.host2.cleanup()
+        super(MultiHostMainline, cls).tearDownClass()
 
-                self._apply_new_profile(new_profiles, host1)
-                # Check everything can contact everything else now
-                self.assert_connectivity(retries=2,
-                                         pass_list=n1_workloads + n2_workloads)
+    wipe_etcd_before_each_test = False
 
-            elif test_type == "rules.tags":
-                profile0_tag = new_profiles[0]['metadata']['tags'][0]
-                profile1_tag = new_profiles[1]['metadata']['tags'][0]
-                rule0 = {'action': 'allow',
-                         'source':
-                             {'tag': profile1_tag}}
-                rule1 = {'action': 'allow',
-                         'source':
-                             {'tag': profile0_tag}}
-                new_profiles[0]['spec']['ingress'].append(rule0)
-                new_profiles[1]['spec']['ingress'].append(rule1)
-                self._apply_new_profile(new_profiles, host1)
-                # Check everything can contact everything else now
-                self.assert_connectivity(retries=3,
-                                         pass_list=n1_workloads + n2_workloads)
+    def setUp(self):
+        super(MultiHostMainline, self).setUp()
+        host1 = self.host1
+        host2 = self.host2
 
-            elif test_type == "rules.protocol.icmp":
-                rule = {'action': 'allow',
-                        'source':
-                            {'protocol': 'icmp'}}
-                # The copy.deepcopy(rule) is needed to ensure that we don't
-                # end up with a yaml document with a reference to the same
-                # rule.  While this is probably legal, it isn't main line.
-                new_profiles[0]['spec']['ingress'].append(rule)
-                new_profiles[1]['spec']['ingress'].append(copy.deepcopy(rule))
-                self._apply_new_profile(new_profiles, host1)
-                # Check everything can contact everything else now
-                self.assert_connectivity(retries=2,
-                                         pass_list=n1_workloads + n2_workloads)
+        (self.n1_workloads, self.n2_workloads, self.networks) = \
+            self._setup_workloads(host1, host2)
 
-            elif test_type == "rules.ip.addr":
-                prof_n1, prof_n2 = self._get_profiles(new_profiles)
-                for workload in n1_workloads:
-                    ip = workload.ip
-                    rule = {'action': 'allow',
-                            'source':
-                                {'net': '%s/32' % ip}}
-                    prof_n2['spec']['ingress'].append(rule)
-                for workload in n2_workloads:
-                    ip = workload.ip
-                    rule = {'action': 'allow',
-                            'source':
-                                {'net': '%s/32' % ip}}
-                    prof_n1['spec']['ingress'].append(rule)
-                self._apply_new_profile(new_profiles, host1)
-                self.assert_connectivity(retries=2,
-                                         pass_list=n1_workloads + n2_workloads)
+        # Get the original profiles:
+        output = host1.calicoctl("get profile -o yaml")
+        self.original_profiles = yaml.safe_load(output)
+        # Make a copy of the profiles to mess about with.
+        self.new_profiles = copy.deepcopy(self.original_profiles)
 
-            elif test_type == "rules.ip.net":
-                prof_n1, prof_n2 = self._get_profiles(new_profiles)
-                n1_ips = [workload.ip for workload in n1_workloads]
-                n2_ips = [workload.ip for workload in n2_workloads]
-                n1_subnet = netaddr.spanning_cidr(n1_ips)
-                n2_subnet = netaddr.spanning_cidr(n2_ips)
-                rule = {'action': 'allow',
-                        'source':
-                            {'net': str(n1_subnet)}}
-                prof_n2['spec']['ingress'].append(rule)
-                rule = {'action': 'allow',
-                        'source':
-                            {'net': str(n2_subnet)}}
-                prof_n1['spec']['ingress'].append(rule)
-                self._apply_new_profile(new_profiles, host1)
-                self.assert_connectivity(retries=2,
-                                         pass_list=n1_workloads + n2_workloads)
-
-            elif test_type == "rules.selector":
-                new_profiles[0]['metadata']['labels'] = {'net': 'n1'}
-                new_profiles[1]['metadata']['labels'] = {'net': 'n2'}
-                rule = {'action': 'allow',
-                        'source':
-                            {'selector': 'net=="n2"'}}
-                new_profiles[0]['spec']['ingress'].append(rule)
-                rule = {'action': 'allow',
-                        'source':
-                            {'selector': "net=='n1'"}}
-                new_profiles[1]['spec']['ingress'].append(rule)
-                self._apply_new_profile(new_profiles, host1)
-                self.assert_connectivity(retries=2,
-                                         pass_list=n1_workloads + n2_workloads)
-
-            elif test_type == "rules.tcp.port":
-                rule = {'action': 'allow',
-                        'protocol': 'tcp',
-                        'destination':
-                            {'ports': [80]}}
-                # The copy.deepcopy(rule) is needed to ensure that we don't
-                # end up with a yaml document with a reference to the same
-                # rule.  While this is probably legal, it isn't main line.
-                new_profiles[0]['spec']['ingress'].append(rule)
-                new_profiles[1]['spec']['ingress'].append(copy.deepcopy(rule))
-                self._apply_new_profile(new_profiles, host1)
-                self.assert_connectivity(retries=2,
-                                         pass_list=n1_workloads + n2_workloads,
-                                         type_list=['tcp'])
-                self.assert_connectivity(retries=2,
-                                         pass_list=n1_workloads,
-                                         fail_list=n2_workloads,
-                                         type_list=['icmp', 'udp'])
-
-            elif test_type == "rules.udp.port":
-                rule = {'action': 'allow',
-                        'protocol': 'udp',
-                        'destination':
-                            {'ports': [69]}}
-                # The copy.deepcopy(rule) is needed to ensure that we don't
-                # end up with a yaml document with a reference to the same
-                # rule.  While this is probably legal, it isn't main line.
-                new_profiles[0]['spec']['ingress'].append(rule)
-                new_profiles[1]['spec']['ingress'].append(copy.deepcopy(rule))
-                self._apply_new_profile(new_profiles, host1)
-                self.assert_connectivity(retries=2,
-                                         pass_list=n1_workloads + n2_workloads,
-                                         type_list=['udp'])
-                self.assert_connectivity(retries=2,
-                                         pass_list=n1_workloads,
-                                         fail_list=n2_workloads,
-                                         type_list=['icmp', 'tcp'])
-
-            else:
-                print "******************* " \
-                      "ERROR - Unrecognised test type " \
-                      "*******************"
-                assert False, "Unrecognised test type: %s" % test_type
-
-            # Now restore the original profile and check it all works as before
-            self._apply_new_profile(original_profiles, host1)
-            host1.calicoctl("get profile -o yaml")
-            self._check_original_connectivity(n1_workloads, n2_workloads)
-
+    def tearDown(self):
+        # Now restore the original profile and check it all works as before
+        self._apply_new_profile(self.original_profiles, self.host1)
+        self.host1.calicoctl("get profile -o yaml")
+        try:
+            self._check_original_connectivity(self.n1_workloads, self.n2_workloads)
+        finally:
             # Tidy up
-            host1.remove_workloads()
-            host2.remove_workloads()
-            for network in networks:
+            self.host1.remove_workloads()
+            self.host2.remove_workloads()
+            for network in self.networks:
                 network.delete()
+
+            super(MultiHostMainline, self).tearDown()
+
+    def test_tags(self):
+        profile0_tag = self.new_profiles[0]['metadata']['tags'][0]
+        profile1_tag = self.new_profiles[1]['metadata']['tags'][0]
+        # Make a new profiles dict where the two networks have each
+        # other in their tags list
+        self.new_profiles[0]['metadata']['tags'].append(profile1_tag)
+        self.new_profiles[1]['metadata']['tags'].append(profile0_tag)
+
+        self._apply_new_profile(self.new_profiles, self.host1)
+        # Check everything can contact everything else now
+        self.assert_connectivity(retries=2,
+                                 pass_list=self.n1_workloads + self.n2_workloads)
+
+    def test_rules_tags(self):
+        profile0_tag = self.new_profiles[0]['metadata']['tags'][0]
+        profile1_tag = self.new_profiles[1]['metadata']['tags'][0]
+        rule0 = {'action': 'allow',
+                 'source':
+                     {'tag': profile1_tag}}
+        rule1 = {'action': 'allow',
+                 'source':
+                     {'tag': profile0_tag}}
+        self.new_profiles[0]['spec']['ingress'].append(rule0)
+        self.new_profiles[1]['spec']['ingress'].append(rule1)
+        self._apply_new_profile(self.new_profiles, self.host1)
+        # Check everything can contact everything else now
+        self.assert_connectivity(retries=3,
+                                 pass_list=self.n1_workloads + self.n2_workloads)
+
+    def test_rules_protocol_icmp(self):
+        rule = {'action': 'allow',
+                'protocol': 'icmp'}
+        # The copy.deepcopy(rule) is needed to ensure that we don't
+        # end up with a yaml document with a reference to the same
+        # rule.  While this is probably legal, it isn't main line.
+        self.new_profiles[0]['spec']['ingress'].append(rule)
+        self.new_profiles[1]['spec']['ingress'].append(copy.deepcopy(rule))
+        self._apply_new_profile(self.new_profiles, self.host1)
+        # Check everything can contact everything else now
+        self.assert_connectivity(retries=2,
+                                 pass_list=self.n1_workloads + self.n2_workloads,
+                                 type_list=["icmp"])
+
+    def test_rules_ip_addr(self):
+        prof_n1, prof_n2 = self._get_profiles(self.new_profiles)
+        for workload in self.n1_workloads:
+            ip = workload.ip
+            rule = {'action': 'allow',
+                    'source':
+                        {'net': '%s/32' % ip}}
+            prof_n2['spec']['ingress'].append(rule)
+        for workload in self.n2_workloads:
+            ip = workload.ip
+            rule = {'action': 'allow',
+                    'source':
+                        {'net': '%s/32' % ip}}
+            prof_n1['spec']['ingress'].append(rule)
+        self._apply_new_profile(self.new_profiles, self.host1)
+        self.assert_connectivity(retries=2,
+                                 pass_list=self.n1_workloads + self.n2_workloads)
+
+    def test_rules_ip_net(self):
+        prof_n1, prof_n2 = self._get_profiles(self.new_profiles)
+        n1_ips = [workload.ip for workload in self.n1_workloads]
+        n2_ips = [workload.ip for workload in self.n2_workloads]
+        n1_subnet = netaddr.spanning_cidr(n1_ips)
+        n2_subnet = netaddr.spanning_cidr(n2_ips)
+        rule = {'action': 'allow',
+                'source':
+                    {'net': str(n1_subnet)}}
+        prof_n2['spec']['ingress'].append(rule)
+        rule = {'action': 'allow',
+                'source':
+                    {'net': str(n2_subnet)}}
+        prof_n1['spec']['ingress'].append(rule)
+        self._apply_new_profile(self.new_profiles, self.host1)
+        self.assert_connectivity(retries=2,
+                                 pass_list=self.n1_workloads + self.n2_workloads)
+
+    def test_rules_selector(self):
+        self.new_profiles[0]['metadata']['labels'] = {'net': 'n1'}
+        self.new_profiles[1]['metadata']['labels'] = {'net': 'n2'}
+        rule = {'action': 'allow',
+                'source':
+                    {'selector': 'net=="n2"'}}
+        self.new_profiles[0]['spec']['ingress'].append(rule)
+        rule = {'action': 'allow',
+                'source':
+                    {'selector': "net=='n1'"}}
+        self.new_profiles[1]['spec']['ingress'].append(rule)
+        self._apply_new_profile(self.new_profiles, self.host1)
+        self.assert_connectivity(retries=2,
+                                 pass_list=self.n1_workloads + self.n2_workloads)
+
+    def test_rules_tcp_port(self):
+        rule = {'action': 'allow',
+                'protocol': 'tcp',
+                'destination':
+                    {'ports': [80]}}
+        # The copy.deepcopy(rule) is needed to ensure that we don't
+        # end up with a yaml document with a reference to the same
+        # rule.  While this is probably legal, it isn't main line.
+        self.new_profiles[0]['spec']['ingress'].append(rule)
+        self.new_profiles[1]['spec']['ingress'].append(copy.deepcopy(rule))
+        self._apply_new_profile(self.new_profiles, self.host1)
+        self.assert_connectivity(retries=2,
+                                 pass_list=self.n1_workloads + self.n2_workloads,
+                                 type_list=['tcp'])
+        self.assert_connectivity(retries=2,
+                                 pass_list=self.n1_workloads,
+                                 fail_list=self.n2_workloads,
+                                 type_list=['icmp', 'udp'])
+
+    def test_rules_udp_port(self):
+            rule = {'action': 'allow',
+                    'protocol': 'udp',
+                    'destination':
+                        {'ports': [69]}}
+            # The copy.deepcopy(rule) is needed to ensure that we don't
+            # end up with a yaml document with a reference to the same
+            # rule.  While this is probably legal, it isn't main line.
+            self.new_profiles[0]['spec']['ingress'].append(rule)
+            self.new_profiles[1]['spec']['ingress'].append(copy.deepcopy(rule))
+            self._apply_new_profile(self.new_profiles, self.host1)
+            self.assert_connectivity(retries=2,
+                                     pass_list=self.n1_workloads + self.n2_workloads,
+                                     type_list=['udp'])
+            self.assert_connectivity(retries=2,
+                                     pass_list=self.n1_workloads,
+                                     fail_list=self.n2_workloads,
+                                     type_list=['icmp', 'tcp'])
 
     @staticmethod
     def _get_profiles(profiles):
@@ -247,10 +235,6 @@ class MultiHostMainline(TestBase):
         host.calicoctl("apply -f new_profiles")
 
     def _setup_workloads(self, host1, host2):
-        # TODO work IPv6 into this test too
-        host1.start_calico_node()
-        host2.start_calico_node()
-
         # Create the networks on host1, but it should be usable from all
         # hosts.  We create one network using the default driver, and the
         # other using the Calico driver.

--- a/tests/st/test_base.py
+++ b/tests/st/test_base.py
@@ -44,13 +44,26 @@ class TestBase(TestCase):
     Base class for test-wide methods.
     """
 
+    wipe_etcd_before_each_test = True
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestBase, cls).setUpClass()
+        wipe_etcd(HOST_IPV4)
+
+    @classmethod
+    def tearDownClass(cls):
+        wipe_etcd(HOST_IPV4)
+        super(TestBase, cls).tearDownClass()
+
     def setUp(self):
         """
         Clean up before every test.
         """
         self.ip = HOST_IPV4
 
-        self.wipe_etcd()
+        if self.wipe_etcd_before_each_test:
+            self.wipe_etcd()
 
         # Log a newline to ensure that the first log appears on its own line.
         logger.info("")

--- a/tests/ut/test_log_parsing.py
+++ b/tests/ut/test_log_parsing.py
@@ -65,6 +65,7 @@ before_data = """2017-01-12 19:19:04.419 [INFO][87] ipip_mgr.go 75: Setting loca
 class LogParsing(TestBase):
     @classmethod
     def setUpClass(cls):
+        super(LogParsing, cls).setUpClass()
         cls.log_banner("TEST SET UP STARTING: %s", cls.__name__)
 
         cls.hosts = []
@@ -87,7 +88,7 @@ class LogParsing(TestBase):
         # Tidy up
         for host in cls.hosts:
             host.cleanup()
-            del host
+        super(LogParsing, cls).tearDownClass()
 
     def setUp(self):
         self.log_banner("starting %s", self._testMethodName)


### PR DESCRIPTION
Use setUpClass and tearDownClass to set up the test environment once for all tests.  This improves performance by sharing the expensive set-up.

Re-instate the tests that were commented out due to the slow per-test set-up.

Fix up some tests that had rotted.