### PR TITLE
calico/node: Fix DISABLE_FILE_LOGGING

### DIFF
--- a/calico_node/filesystem/etc/rc.local
+++ b/calico_node/filesystem/etc/rc.local
@@ -82,11 +82,12 @@ if [ "$CALICO_LIBNETWORK_ENABLED" == "true" ]; then
 fi
 
 if [ "$CALICO_DISABLE_FILE_LOGGING" == "true" ]; then
-	rm -r /etc/service/available/bird/log
-	rm -r /etc/service/available/bird6/log
-	rm -r /etc/service/available/confd/log
-	rm -r /etc/service/available/felix/log
-	rm -r /etc/service/available/calico-bgp-daemon/log
+	rm -r /etc/service/enabled/bird/log
+	rm -r /etc/service/enabled/bird6/log
+	rm -r /etc/service/enabled/confd/log
+	rm -r /etc/service/enabled/felix/log
+	rm -r /etc/service/enabled/libnetwork/log
+	rm -r /etc/service/enabled/calico-bgp-daemon/log
 fi
 
 echo "Calico node started successfully"


### PR DESCRIPTION
Delete the log directories in the "enabled" not "available" directories

Fixes #1519