### PR TITLE
Check if IPIP pools are disabled before assigning IP, and update tunl IP when pool is disabled

### DIFF
--- a/calico_node/allocateipip/allocate_ipip_addr.go
+++ b/calico_node/allocateipip/allocate_ipip_addr.go
@@ -130,7 +130,8 @@ func getIPIPEnabledPoolCIDRs(c *client.Client) []net.IPNet {
 
 	var cidrs []net.IPNet
 	for _, ipPool := range ipPoolList.Items {
-		if ipPool.Spec.IPIP != nil && ipPool.Spec.IPIP.Enabled {
+		// Check if IPIP is enabled in the IP pool, the IP pool is not disabled, and it is IPv4 pool since we don't support IPIP with IPv6.
+		if ipPool.Spec.IPIP != nil && ipPool.Spec.IPIP.Enabled && !ipPool.Spec.Disabled && ipPool.Metadata.CIDR.Version() == 4 {
 			cidrs = append(cidrs, ipPool.Metadata.CIDR)
 		}
 	}

--- a/calico_node/filesystem/etc/calico/confd/templates/tunl-ip.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/tunl-ip.template
@@ -3,5 +3,5 @@ Otherwise, confd notices the file hasn't changed and won't
 run our python update script.
  
 {{range ls "/pool"}}{{$data := json (getv (printf "/pool/%s" .))}}
-  {{if $data.ipip}}{{$data.cidr}}{{end}}
+  {{if $data.ipip}}{{if not $data.disabled}}{{$data.cidr}}{{end}}{{end}}
 {{end}}

--- a/tests/st/calicoctl/test_ipip.py
+++ b/tests/st/calicoctl/test_ipip.py
@@ -136,6 +136,14 @@ class TestIPIP(TestBase):
             host.start_calico_node()
             self.assert_tunl_ip(host, ipv4_pool, expect=True)
 
+            # Disable the IP Pool, and make sure the tunl IP is not from this IP pool anymore. 
+            self.pool_action(host, "apply", ipv4_pool, True, True)
+            self.assert_tunl_ip(host, ipv4_pool, expect=False)
+
+            # Re-enable the IP pool and make sure the tunl IP is assigned from that IP pool again.
+            self.pool_action(host, "apply", ipv4_pool, True, False)
+            self.assert_tunl_ip(host, ipv4_pool, expect=True)
+            
             # Test that removing pool removes the tunl IP.
             self.pool_action(host, "delete", ipv4_pool, True)
             self.assert_tunl_ip(host, ipv4_pool, expect=False)
@@ -151,7 +159,7 @@ class TestIPIP(TestBase):
             self.pool_action(host, "delete", ipv4_pool, True)
             self.assert_tunl_ip(host, new_ipv4_pool)
 
-    def pool_action(self, host, action, cidr, ipip, ipip_mode="", calicoctl_version=None):
+    def pool_action(self, host, action, cidr, ipip, disabled=False, ipip_mode="", calicoctl_version=None):
         """
         Perform an ipPool action.
         """
@@ -164,7 +172,8 @@ class TestIPIP(TestBase):
             'spec': {
                 'ipip': {
                     'enabled': ipip
-                }
+                },
+                'disabled': disabled
             }
         }
 

--- a/tests/st/calicoctl/test_ipip.py
+++ b/tests/st/calicoctl/test_ipip.py
@@ -137,13 +137,13 @@ class TestIPIP(TestBase):
             self.assert_tunl_ip(host, ipv4_pool, expect=True)
 
             # Disable the IP Pool, and make sure the tunl IP is not from this IP pool anymore. 
-            self.pool_action(host, "apply", ipv4_pool, True, True)
+            self.pool_action(host, "apply", ipv4_pool, True, disabled=True)
             self.assert_tunl_ip(host, ipv4_pool, expect=False)
 
             # Re-enable the IP pool and make sure the tunl IP is assigned from that IP pool again.
-            self.pool_action(host, "apply", ipv4_pool, True, False)
+            self.pool_action(host, "apply", ipv4_pool, True)
             self.assert_tunl_ip(host, ipv4_pool, expect=True)
-            
+
             # Test that removing pool removes the tunl IP.
             self.pool_action(host, "delete", ipv4_pool, True)
             self.assert_tunl_ip(host, ipv4_pool, expect=False)


### PR DESCRIPTION
Fixes #1530 
Fixes #1533 