### PR TITLE
Updating startup.go for Kubernetes Datastore Driver with bird

### DIFF
--- a/Makefile.calico-node
+++ b/Makefile.calico-node
@@ -12,7 +12,7 @@ BIRD_VER := v0.2.0
 GOBGPD_VER := v0.2.0
 FELIX_VER := 2.1.0
 LIBNETWORK_PLUGIN_VER := v1.1.0
-CONFD_VER := v0.10.0-scale
+CONFD_VER := v0.11.0
 SYSTEMTEST_CONTAINER_VER := latest
 
 ###############################################################################

--- a/calico_node/filesystem/etc/rc.local
+++ b/calico_node/filesystem/etc/rc.local
@@ -1,11 +1,11 @@
 # Handle old CALICO_NETWORKING environment by converting to the new config.
 if [ -n "$CALICO_NETWORKING" ]; then
-    echo 'WARNING: $CALICO_NETWORKING will be deprecated: use $CALICO_NETWORKING_BACKEND instead'
-    if [ "$CALICO_NETWORKING" == "false" ]; then
-        export CALICO_NETWORKING_BACKEND=none
-    else
-        export CALICO_NETWORKING_BACKEND=bird
-    fi
+	echo 'WARNING: $CALICO_NETWORKING will be deprecated: use $CALICO_NETWORKING_BACKEND instead'
+	if [ "$CALICO_NETWORKING" == "false" ]; then
+		export CALICO_NETWORKING_BACKEND=none
+	else
+		export CALICO_NETWORKING_BACKEND=bird
+	fi
 fi
 
 # Run the startup initialisation script.  These ensure the node is correctly
@@ -34,16 +34,16 @@ if [ -z "$CALICO_DISABLE_FELIX" ]; then
 fi
 
 case "$CALICO_NETWORKING_BACKEND" in
-    "none" )
+	"none" )
 	# If running in policy only mode, we don't need to run BIRD / Confd.
 	echo "CALICO_NETWORKING_BACKEND is none - no BGP daemon running"
 	;;
-    "gobgp" )
+	"gobgp" )
 	# Run calico-bgp-daemon instead of BIRD / Confd.
 	echo "CALICO_NETWORKING_BACKEND is gobgp - run calico-bgp-daemon"
 	cp -a /etc/service/available/calico-bgp-daemon /etc/service/enabled/
 	;;
-    * )
+	* )
 	# Run BIRD / Confd.
 	#
 	# Run Confd in onetime mode, to ensure that we have a working config in place to allow bird(s) and
@@ -57,18 +57,23 @@ case "$CALICO_NETWORKING_BACKEND" in
 
 	# Run confd twice.  Our confd TOML files are also generated from confd, so
 	# running twice ensures our starting configuration is correct.
-	# Use ETCD_ENDPOINTS in preferences to ETCD_AUTHORITY
-	ETCD_NODE=${ETCD_ENDPOINTS:=${ETCD_SCHEME:=http}://${ETCD_AUTHORITY}}
+	if [ "$DATASTORE_TYPE" = "kubernetes" ]; then
+		confd -onetime -backend=k8s -confdir=/etc/calico/confd -log-level=debug -keep-stage-file >/felix-startup-1.log 2>&1 || true
+		confd -onetime -backend=k8s -confdir=/etc/calico/confd -log-level=debug -keep-stage-file >/felix-startup-2.log 2>&1 || true
+	else
+		# Use ETCD_ENDPOINTS in preferences to ETCD_AUTHORITY
+		ETCD_NODE=${ETCD_ENDPOINTS:=${ETCD_SCHEME:=http}://${ETCD_AUTHORITY}}
 
-	# confd needs a "-node" arguments for each etcd endpoint.
-	ETCD_ENDPOINTS_CONFD=`echo "-node=$ETCD_NODE" | sed -e 's/,/ -node=/g'`
+		# confd needs a "-node" arguments for each etcd endpoint.
+		ETCD_ENDPOINTS_CONFD=`echo "-node=$ETCD_NODE" | sed -e 's/,/ -node=/g'`
 
-	confd -confdir=/etc/calico/confd -onetime ${ETCD_ENDPOINTS_CONFD} -no-discover \
-	      -client-key=${ETCD_KEY_FILE} -client-cert=${ETCD_CERT_FILE} \
-	      -client-ca-keys=${ETCD_CA_CERT_FILE} -keep-stage-file >/felix-startup-1.log 2>&1 || true
-	confd -confdir=/etc/calico/confd -onetime ${ETCD_ENDPOINTS_CONFD} -no-discover \
-	      -client-key=${ETCD_KEY_FILE} -client-cert=${ETCD_CERT_FILE} \
-	      -client-ca-keys=${ETCD_CA_CERT_FILE} -keep-stage-file >/felix-startup-2.log 2>&1 || true
+		confd -confdir=/etc/calico/confd -onetime ${ETCD_ENDPOINTS_CONFD} -no-discover \
+			  -client-key=${ETCD_KEY_FILE} -client-cert=${ETCD_CERT_FILE} \
+			  -client-ca-keys=${ETCD_CA_CERT_FILE} -keep-stage-file >/felix-startup-1.log 2>&1 || true
+		confd -confdir=/etc/calico/confd -onetime ${ETCD_ENDPOINTS_CONFD} -no-discover \
+			  -client-key=${ETCD_KEY_FILE} -client-cert=${ETCD_CERT_FILE} \
+			  -client-ca-keys=${ETCD_CA_CERT_FILE} -keep-stage-file >/felix-startup-2.log 2>&1 || true
+	fi
 
 	# Enable the confd and bird services
 	cp -a /etc/service/available/bird  /etc/service/enabled/

--- a/calico_node/filesystem/etc/service/available/confd/run
+++ b/calico_node/filesystem/etc/service/available/confd/run
@@ -1,8 +1,14 @@
 #!/bin/sh
 exec 2>&1
-ETCD_NODE=${ETCD_ENDPOINTS:=${ETCD_SCHEME:=http}://${ETCD_AUTHORITY}}
-ETCD_ENDPOINTS_CONFD=`echo "-node=$ETCD_NODE" | sed -e 's/,/ -node=/g'`
 
-exec confd -confdir=/etc/calico/confd -interval=5 -watch -no-discover --log-level=debug \
+if [ "$DATASTORE_TYPE" = "kubernetes" ]
+then
+    exec confd -confdir=/etc/calico/confd -interval=5 -log-level=debug -backend=k8s
+else
+    ETCD_NODE=${ETCD_ENDPOINTS:=${ETCD_SCHEME:=http}://${ETCD_AUTHORITY}}
+    ETCD_ENDPOINTS_CONFD=`echo "-node=$ETCD_NODE" | sed -e 's/,/ -node=/g'`
+
+    exec confd -confdir=/etc/calico/confd -interval=5 -watch -no-discover --log-level=debug \
            $ETCD_ENDPOINTS_CONFD -client-key=${ETCD_KEY_FILE} \
            -client-cert=${ETCD_CERT_FILE} -client-ca-keys=${ETCD_CA_CERT_FILE}
+fi

--- a/glide.lock
+++ b/glide.lock
@@ -177,7 +177,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 8de5b8d6e6f0a44208f033e208a2dec986abedb8
+  version: 145b1337740162dba4f0702bf24d2075f66026e1
   subpackages:
   - lib/api
   - lib/api/unversioned

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,7 +21,7 @@ import:
   - json
 - package: github.com/projectcalico/go-yaml-wrapper
 - package: github.com/projectcalico/libcalico-go
-  version: 1.1.1
+  version: 145b1337740162dba4f0702bf24d2075f66026e1
   subpackages:
   - lib/api
   - lib/api/unversioned


### PR DESCRIPTION
This PR coincides with a PR for libcalico-go and projectcalico/confd here:

projectcalico/libcalico-go#354
projectcalico/confd#4

With those two PRs this will allow calico/node to operate with the Kubernetes Datastore Driver and Bird BGP routing enabled in node-mesh mode.

- Updated the shell scripts to detect if running KDD and launch confd accordingly
- startup.go modifications to push all of the required info to KDD