### PR TITLE
Turn off confd discovery

### DIFF
--- a/calico_node/filesystem/etc/rc.local
+++ b/calico_node/filesystem/etc/rc.local
@@ -63,10 +63,10 @@ case "$CALICO_NETWORKING_BACKEND" in
 	# confd needs a "-node" arguments for each etcd endpoint.
 	ETCD_ENDPOINTS_CONFD=`echo "-node=$ETCD_NODE" | sed -e 's/,/ -node=/g'`
 
-	confd -confdir=/etc/calico/confd -onetime ${ETCD_ENDPOINTS_CONFD} \
+	confd -confdir=/etc/calico/confd -onetime ${ETCD_ENDPOINTS_CONFD} -no-discover \
 	      -client-key=${ETCD_KEY_FILE} -client-cert=${ETCD_CERT_FILE} \
 	      -client-ca-keys=${ETCD_CA_CERT_FILE} -keep-stage-file >/felix-startup-1.log 2>&1 || true
-	confd -confdir=/etc/calico/confd -onetime ${ETCD_ENDPOINTS_CONFD} \
+	confd -confdir=/etc/calico/confd -onetime ${ETCD_ENDPOINTS_CONFD} -no-discover \
 	      -client-key=${ETCD_KEY_FILE} -client-cert=${ETCD_CERT_FILE} \
 	      -client-ca-keys=${ETCD_CA_CERT_FILE} -keep-stage-file >/felix-startup-2.log 2>&1 || true
 

--- a/calico_node/filesystem/etc/service/available/confd/run
+++ b/calico_node/filesystem/etc/service/available/confd/run
@@ -3,6 +3,6 @@ exec 2>&1
 ETCD_NODE=${ETCD_ENDPOINTS:=${ETCD_SCHEME:=http}://${ETCD_AUTHORITY}}
 ETCD_ENDPOINTS_CONFD=`echo "-node=$ETCD_NODE" | sed -e 's/,/ -node=/g'`
 
-exec confd -confdir=/etc/calico/confd -interval=5 -watch --log-level=debug \
+exec confd -confdir=/etc/calico/confd -interval=5 -watch -no-discover --log-level=debug \
            $ETCD_ENDPOINTS_CONFD -client-key=${ETCD_KEY_FILE} \
            -client-cert=${ETCD_CERT_FILE} -client-ca-keys=${ETCD_CA_CERT_FILE}


### PR DESCRIPTION
This one's a doozy.

There's a bug in etcd (3.1.0, 3.1.1, and 3.1.2) where [advertise-client-urls is always overwritten to be localhost:2379, even when it is manually set to something else](https://github.com/coreos/etcd/issues/7348). 

If I have a client programmed to connect to a remote etcd, and my client has "discovery" turned on, the etcd server will tell the client to reconnect via `localhost:2379`. If my client isn't on the same node as etcd, this will of course fail.

Currently, all other calico components besides confd (i.e. Felix, startup.go, calicoctl, and k8s-policy) do not connect with "discovery" on. They ignore the bad advertise url and have no issue reading and writing from etcd.

Confd, however, defaults to discovery mode. It will reconnect to localhost and fail repeatedly printing the following message:

`2017-03-10T23:29:26Z my-host-30j9 confd[57]: ERROR 501: All the given peers are not reachable (failed to propose on members [https://localhost:2379] twice [last error: Get https://localhost:2379/v2/keys/calico/v1/ipam/v6?quorum=false&recursive=true&sorted=false: dial tcp 127.0.0.1:2379: connection refused]) [0]`

This PR turns off discovery mode in confd, preventing this from happening.