### PR TITLE
Update templates to handle missing node BGP IP

### DIFF
--- a/calico_node/filesystem/etc/calico/confd/templates/bird.cfg.mesh.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird.cfg.mesh.template
@@ -62,13 +62,13 @@ template bgp bgp_template {
 {{if (json (getv "/global/node_mesh")).enabled}}
 {{range $host := lsdir "/host"}}
 {{$onode_as_key := printf "/host/%s/as_num" .}}
-{{$onode_ip_key := printf "/host/%s/ip_addr_v4" .}}{{$onode_ip := getv $onode_ip_key}}
+{{$onode_ip_key := printf "/host/%s/ip_addr_v4" .}}{{if exists $onode_ip_key}}{{$onode_ip := getv $onode_ip_key}}
 {{$nums := split $onode_ip "."}}{{$id := join $nums "_"}}
 # For peer {{$onode_ip_key}}
 {{if eq $onode_ip ($node_ip) }}# Skipping ourselves ({{$node_ip}})
 {{else if ne "" $onode_ip}}protocol bgp Mesh_{{$id}} from bgp_template {
   neighbor {{$onode_ip}} as {{if exists $onode_as_key}}{{getv $onode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
-}{{end}}{{end}}
+}{{end}}{{end}}{{end}}
 {{else}}
 # Node-to-node mesh disabled
 {{end}}

--- a/calico_node/filesystem/etc/calico/confd/templates/bird6.cfg.mesh.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/bird6.cfg.mesh.template
@@ -64,14 +64,14 @@ template bgp bgp_template {
 {{if (json (getv "/global/node_mesh")).enabled}}
 {{range $host := lsdir "/host"}}
 {{$onode_as_key := printf "/host/%s/as_num" .}}
-{{$onode_ip_key := printf "/host/%s/ip_addr_v6" .}}{{$onode_ip := getv $onode_ip_key}}
+{{$onode_ip_key := printf "/host/%s/ip_addr_v6" .}}{{if exists $onode_ip_key}}{{$onode_ip := getv $onode_ip_key}}
 {{$nums := split $onode_ip ":"}}{{$id := join $nums "_"}}
 # For peer {{$onode_ip_key}}
 {{if eq $onode_ip ($node_ip6) }}# Skipping ourselves ({{$node_ip6}})
 {{else if eq "" $onode_ip}}# No IPv6 address configured for this node
 {{else}}protocol bgp Mesh_{{$id}} from bgp_template {
   neighbor {{$onode_ip}} as {{if exists $onode_as_key}}{{getv $onode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
-}{{end}}{{end}}
+}{{end}}{{end}}{{end}}
 {{else}}
 # Node-to-node mesh disabled
 {{end}}


### PR DESCRIPTION
Check that the IPv4 address key is present before trying to get the value.

It's a very "mainline" change in the template so it's getting good coverage in the STs, but there is no ST to test the actual issue that led to us wanting this fix (since that would require jimmying around in etcd).