### PR TITLE
Use BIRD v0.3.0

### DIFF
--- a/Makefile.calico-node
+++ b/Makefile.calico-node
@@ -8,7 +8,7 @@ SYSTEMTEST_CONTAINER?=calico/test:$(SYSTEMTEST_CONTAINER_VER)
 CALICOCONTAINERS_VERSION?=$(shell git describe --tags --dirty --always)
 ###############################################################################
 # Subcomponent versions:
-BIRD_VER := v0.2.0
+BIRD_VER := v0.3.0
 GOBGPD_VER := v0.2.0
 FELIX_VER := 2.1.1
 LIBNETWORK_PLUGIN_VER := v1.1.0


### PR DESCRIPTION
From https://github.com/projectcalico/bird/releases/tag/v0.3.0 :

Merge Calico's BIRD patches with the upstream BIRD 1.6.3 code.

Calico's BIRD fork was previously based on BIRD 1.5.0, so this merge
brings in the following upstream BIRD changes (notes from
http://bird.network.cz/?o_news).

- 1.6.0 (29.4.2016) RIP protocol redesigned, new protocol babel, BGP
  multipath added.

- 1.6.1 (22.9.2016) IPv6 ECMP support, several improvements in filters,
  kernel protocol, babel, memory leak in BGP multipath fixed.

- 1.6.2 (29.9.2016) Fixed serious bug of the previous version.

- 1.6.3 (22.12.2016) Large BGP communities, new authentication in BFD,
  RIP and OSPF.

Of particular interest for Calico is the BGP multipath and ECMP support
- see the documentation for merge paths at
http://bird.network.cz/?get_doc&f=bird-6.html#ss6.3. It means that if a
deployment has multiple equal cost routes between its compute hosts,
traffic between workloads on those hosts will be automatically balanced
across the available routes.