### PR TITLE
Rev Felix to 2.2.0-pre1.

### DIFF
--- a/Makefile.calico-node
+++ b/Makefile.calico-node
@@ -10,7 +10,7 @@ CALICOCONTAINERS_VERSION?=$(shell git describe --tags --dirty --always)
 # Subcomponent versions:
 BIRD_VER := v0.3.0
 GOBGPD_VER := v0.2.0
-FELIX_VER := 2.1.1
+FELIX_VER := 2.2.0-pre1
 LIBNETWORK_PLUGIN_VER := v1.1.0
 CONFD_VER := v0.11.0
 SYSTEMTEST_CONTAINER_VER := latest


### PR DESCRIPTION
Rev Felix to this version to give it more exposure: https://github.com/projectcalico/felix/releases/tag/2.2.0-pre1