### PR TITLE
Disable Felix syslog logging, which doesn't work inside calico/node.

### DIFF
--- a/calico_node/filesystem/etc/calico/felix.cfg
+++ b/calico_node/filesystem/etc/calico/felix.cfg
@@ -2,3 +2,4 @@
 MetadataAddr = None
 LogFilePath = None
 LogSeverityFile = None
+LogSeveritySys = None


### PR DESCRIPTION
Should avoid this warning emitted at startup:
```
2017-04-07 08:33:33.120 [ERROR][40] logutils.go 147: Failed to connect to syslog error=Unix syslog delivery error level="WARNING"
```