### PR TITLE
Added parameter CALICO_NAT_OUTGOING for default IPPool Creation

### DIFF
--- a/calico_node/startup/startup.go
+++ b/calico_node/startup/startup.go
@@ -342,9 +342,10 @@ func validateIP(ipn *net.IPNet) {
 }
 
 // evaluateENVBool evaluates a passed environment variable
-// Returns an boolean indicating if the parameter was defined
-// and an boolean if the argument was true or false
-// If an log entry will always be written
+// Returns True if the envVar is defined and set to true.
+// Returns False if the envVar is defined and set to false.
+// Returns def in the envVar is not defined.
+// An log entry will always be written
 func evaluateENVBool(envVar string, defaultValue bool) bool {
 	envValue, isEmpty := os.LookupEnv(envVar)
 

--- a/calico_node/startup/startup_test.go
+++ b/calico_node/startup/startup_test.go
@@ -69,7 +69,7 @@ type EnvItem struct {
 }
 
 var _ = Describe("FV tests against a real etcd", func() {
-	changedEnvVars := []string{"CALICO_IPV4POOL_CIDR", "CALICO_IPV6POOL_CIDR", "NO_DEFAULT_POOLS", "CALICO_IPV4POOL_IPIP"}
+	changedEnvVars := []string{"CALICO_IPV4POOL_CIDR", "CALICO_IPV6POOL_CIDR", "NO_DEFAULT_POOLS", "CALICO_IPV4POOL_IPIP", "CALICO_IPV6POOL_NAT_OUTGOING", "CALICO_IPV4POOL_NAT_OUTGOING"}
 
 	BeforeEach(func() {
 		for _, envName := range changedEnvVars {
@@ -83,7 +83,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 	})
 
 	DescribeTable("Test IP pool env variables",
-		func(envList []EnvItem, expectedIPv4 string, expectedIPv6 string, expectIpv4IpipMode string) {
+		func(envList []EnvItem, expectedIPv4 string, expectedIPv6 string, expectIpv4IpipMode string, expectedIPV4NATOutgoing bool, expectedIPV6NATOutgoing bool) {
 			// Create a new client.
 			cfg, _ := client.LoadClientConfigFromEnvironment()
 			c := testutils.CreateCleanClient(*cfg)
@@ -106,6 +106,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 			// Look through the pool for the expected data.
 			foundv4Expected := false
 			foundv6Expected := false
+
 			for _, pool := range poolList.Items {
 				if pool.Metadata.CIDR.String() == expectedIPv4 {
 					foundv4Expected = true
@@ -118,6 +119,13 @@ var _ = Describe("FV tests against a real etcd", func() {
 					if pool.Spec.IPIP != nil {
 						Expect(pool.Spec.IPIP.Enabled).To(BeFalse())
 					}
+
+					if expectedIPV6NATOutgoing {
+						Expect(pool.Spec.NATOutgoing).To(BeTrue())
+					} else {
+						Expect(pool.Spec.NATOutgoing).To(BeFalse())
+					}
+
 				} else {
 					// off is not a real mode value but use it instead of empty string
 					if expectIpv4IpipMode == "off" {
@@ -128,6 +136,13 @@ var _ = Describe("FV tests against a real etcd", func() {
 						Expect(pool.Spec.IPIP.Enabled).To(BeTrue())
 						Expect(pool.Spec.IPIP.Mode).To(Equal(ipip.Mode(expectIpv4IpipMode)))
 					}
+
+					if expectedIPV4NATOutgoing == false {
+						Expect(pool.Spec.NATOutgoing).To(BeFalse())
+					} else {
+						Expect(pool.Spec.NATOutgoing).To(BeTrue())
+					}
+
 				}
 			}
 			Expect(foundv4Expected).To(BeTrue(),
@@ -137,31 +152,49 @@ var _ = Describe("FV tests against a real etcd", func() {
 		},
 
 		Entry("No env variables set", []EnvItem{},
-			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "off"),
+			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "off", true, false),
 		Entry("IPv4 Pool env var set",
 			[]EnvItem{{"CALICO_IPV4POOL_CIDR", "172.16.0.0/24"}},
-			"172.16.0.0/24", "fd80:24e2:f998:72d6::/64", "off"),
+			"172.16.0.0/24", "fd80:24e2:f998:72d6::/64", "off", true, false),
 		Entry("IPv6 Pool env var set",
 			[]EnvItem{{"CALICO_IPV6POOL_CIDR", "fdff:ffff:ffff:ffff:ffff::/80"}},
-			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "off"),
+			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "off", true, false),
 		Entry("Both IPv4 and IPv6 Pool env var set",
 			[]EnvItem{
 				{"CALICO_IPV4POOL_CIDR", "172.16.0.0/24"},
 				{"CALICO_IPV6POOL_CIDR", "fdff:ffff:ffff:ffff:ffff::/80"},
 			},
-			"172.16.0.0/24", "fdff:ffff:ffff:ffff:ffff::/80", "off"),
+			"172.16.0.0/24", "fdff:ffff:ffff:ffff:ffff::/80", "off", true, false),
 		Entry("CALICO_IPV4POOL_IPIP set off", []EnvItem{{"CALICO_IPV4POOL_IPIP", "off"}},
-			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "off"),
+			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "off", true, false),
 		Entry("CALICO_IPV4POOL_IPIP set always", []EnvItem{{"CALICO_IPV4POOL_IPIP", "always"}},
-			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "always"),
+			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "always", true, false),
 		Entry("CALICO_IPV4POOL_IPIP set cross-subnet", []EnvItem{{"CALICO_IPV4POOL_IPIP", "cross-subnet"}},
-			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "cross-subnet"),
+			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "cross-subnet", true, false),
 		Entry("IPv6 Pool and IPIP set",
 			[]EnvItem{
 				{"CALICO_IPV6POOL_CIDR", "fdff:ffff:ffff:ffff:ffff::/80"},
 				{"CALICO_IPV4POOL_IPIP", "always"},
 			},
-			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "always"),
+			"192.168.0.0/16", "fdff:ffff:ffff:ffff:ffff::/80", "always", true, false),
+		Entry("IPv6 NATOutgoing Set Enabled",
+			[]EnvItem{
+				{"CALICO_IPV6POOL_NAT_OUTGOING", "true"}},
+			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "off", true, true),
+		Entry("IPv6 NATOutgoing Set Disabled",
+			[]EnvItem{
+				{"CALICO_IPV6POOL_NAT_OUTGOING", "false"}},
+			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "off", true, false),
+		Entry("IPv4 NATOutgoing Set Disabled",
+			[]EnvItem{
+				{"CALICO_IPV4POOL_NAT_OUTGOING", "false"}},
+			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "off", false, false),
+		Entry("IPv6 NAT OUTGOING and IPV4 NAT OUTGOING SET",
+			[]EnvItem{
+				{"CALICO_IPV4POOL_NAT_OUTGOING", "false"},
+				{"CALICO_IPV6POOL_NAT_OUTGOING", "true"},
+			},
+			"192.168.0.0/16", "fd80:24e2:f998:72d6::/64", "off", false, true),
 	)
 
 	Describe("Test NO_DEFAULT_POOLS env variable", func() {

--- a/calico_node/startup/startup_test.go
+++ b/calico_node/startup/startup_test.go
@@ -120,11 +120,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 						Expect(pool.Spec.IPIP.Enabled).To(BeFalse())
 					}
 
-					if expectedIPV6NATOutgoing {
-						Expect(pool.Spec.NATOutgoing).To(BeTrue())
-					} else {
-						Expect(pool.Spec.NATOutgoing).To(BeFalse())
-					}
+					Expect(pool.Spec.NATOutgoing).To(Equal(expectedIPV6NATOutgoing))
 
 				} else {
 					// off is not a real mode value but use it instead of empty string
@@ -137,11 +133,7 @@ var _ = Describe("FV tests against a real etcd", func() {
 						Expect(pool.Spec.IPIP.Mode).To(Equal(ipip.Mode(expectIpv4IpipMode)))
 					}
 
-					if expectedIPV4NATOutgoing == false {
-						Expect(pool.Spec.NATOutgoing).To(BeFalse())
-					} else {
-						Expect(pool.Spec.NATOutgoing).To(BeTrue())
-					}
+					Expect(pool.Spec.NATOutgoing).To(Equal(expectedIPV4NATOutgoing))
 
 				}
 			}

--- a/tests/st/calicoctl/test_default_pools.py
+++ b/tests/st/calicoctl/test_default_pools.py
@@ -49,33 +49,33 @@ class TestDefaultPools(TestBase):
             cls.host.cleanup()
 
     @parameterized.expand([
-        (False, "CALICO_IPV4POOL_CIDR", "10.0.0.0/27", 0, None, "Too small"),
-        (False, "CALICO_IPV4POOL_CIDR", "10.0.0.0/32", 0, None, "Too small, but legal CIDR"),
-        (False, "CALICO_IPV4POOL_CIDR", "10.0.0.0/33", 0, None, "Impossible CIDR"),
-        (False, "CALICO_IPV4POOL_CIDR", "256.0.0.0/24", 0, None, "Invalid IP"),
-        (True, "CALICO_IPV4POOL_CIDR", "10.0.0.0/24", 2, None, "Typical non-default pool"),
-        (True, "CALICO_IPV4POOL_CIDR", "10.0.0.0/26", 2, None, "Smallest legal pool"),
-        (True, "CALICO_IPV6POOL_CIDR", "fd00::/122", 2, None, "Smallest legal pool"),
-        (False, "CALICO_IPV6POOL_CIDR", "fd00::/123", 0, None, "Too small"),
-        (False, "CALICO_IPV6POOL_CIDR", "fd00::/128", 0, None, "Too small, but legal CIDR"),
-        (False, "CALICO_IPV6POOL_CIDR", "fd00::/129", 0, None, "Impossible CIDR"),
-        (True, "CALICO_IPV4POOL_CIDR", "10.0.0.0/24", 2, "cross-subnet", "Typ. non-def pool, IPIP"),
-        (True, "CALICO_IPV4POOL_CIDR", "10.0.0.0/24", 2, "always", "Typ. non-default pool, IPIP"),
-        (True, "CALICO_IPV4POOL_CIDR", "10.0.0.0/24", 2, "off", "Typical pool, explicitly no IPIP"),
-        (True, "CALICO_IPV6POOL_CIDR", "fd00::/122", 2, "always", "IPv6 - IPIP not permitted"),
-        (True, "CALICO_IPV6POOL_CIDR", "fd00::/122", 2, "cross-subnet", "IPv6 - IPIP not allowed"),
-        (True, "CALICO_IPV6POOL_CIDR", "fd00::/122", 2, "off", "IPv6, IPIP explicitly off"),
-        (False, "CALICO_IPV6POOL_CIDR", "fd00::/122", 0, "junk", "Invalid IPIP value"),
-        (False, "CALICO_IPV4POOL_CIDR", "10.0.0.0/24", 0, "reboot", "Invalid IPIP value"),
-        (False, "CALICO_IPV4POOL_CIDR", "0.0.0.0/0", 0, None, "Invalid, link local address"),
-        (False, "CALICO_IPV6POOL_CIDR", "::/0", 0, None, "Invalid, link local address"),
-        (True, "CALICO_IPV6POOL_CIDR", "fd80::0:0/120", 2, None, "Valid, but non-canonical form"),
-        (False, "CALICO_IPV6POOL_CIDR", "1.2.3.4/24", 0, None, "Wrong type"),
-        (False, "CALICO_IPV4POOL_CIDR", "fd00::/24", 0, None, "Wrong type"),
-        (True, "CALICO_IPV6POOL_CIDR", "::0:a:b:c:d:e:0/120", 2, None, "Valid, non-canonical form"),
-        (False, "CALICO_IPV4POOL_CIDR", "1.2/16", 0, None, "Valid, unusual form"),
+        (False, "CALICO_IPV4POOL_CIDR", "10.0.0.0/27", 0, None, True, "Too small"),
+        (False, "CALICO_IPV4POOL_CIDR", "10.0.0.0/32", 0, None, True, "Too small, but legal CIDR"),
+        (False, "CALICO_IPV4POOL_CIDR", "10.0.0.0/33", 0, None, True, "Impossible CIDR"),
+        (False, "CALICO_IPV4POOL_CIDR", "256.0.0.0/24", 0, None, True, "Invalid IP"),
+        (True, "CALICO_IPV4POOL_CIDR", "10.0.0.0/24", 2, None, True, "Typical non-default pool"),
+        (True, "CALICO_IPV4POOL_CIDR", "10.0.0.0/26", 2, None, True, "Smallest legal pool"),
+        (True, "CALICO_IPV6POOL_CIDR", "fd00::/122", 2, None, False, "Smallest legal pool"),
+        (False, "CALICO_IPV6POOL_CIDR", "fd00::/123", 0, None, False, "Too small"),
+        (False, "CALICO_IPV6POOL_CIDR", "fd00::/128", 0, None, False, "Too small, but legal CIDR"),
+        (False, "CALICO_IPV6POOL_CIDR", "fd00::/129", 0, None, False, "Impossible CIDR"),
+        (True, "CALICO_IPV4POOL_CIDR", "10.0.0.0/24", 2, "cross-subnet", True,"Typ. non-def pool, IPIP"),
+        (True, "CALICO_IPV4POOL_CIDR", "10.0.0.0/24", 2, "always", True,"Typ. non-default pool, IPIP"),
+        (True, "CALICO_IPV4POOL_CIDR", "10.0.0.0/24", 2, "off", True, "Typical pool, explicitly no IPIP"),
+        (True, "CALICO_IPV6POOL_CIDR", "fd00::/122", 2, "always", False, "IPv6 - IPIP not permitted"),
+        (True, "CALICO_IPV6POOL_CIDR", "fd00::/122", 2, "cross-subnet", False, "IPv6 - IPIP not allowed"),
+        (True, "CALICO_IPV6POOL_CIDR", "fd00::/122", 2, "off", False, "IPv6, IPIP explicitly off"),
+        (False, "CALICO_IPV6POOL_CIDR", "fd00::/122", 0, "junk", False, "Invalid IPIP value"),
+        (False, "CALICO_IPV4POOL_CIDR", "10.0.0.0/24", 0, "reboot", True, "Invalid IPIP value"),
+        (False, "CALICO_IPV4POOL_CIDR", "0.0.0.0/0", 0, None, True, "Invalid, link local address"),
+        (False, "CALICO_IPV6POOL_CIDR", "::/0", 0, None, False, "Invalid, link local address"),
+        (True, "CALICO_IPV6POOL_CIDR", "fd80::0:0/120", 2, None, False, "Valid, but non-canonical form"),
+        (False, "CALICO_IPV6POOL_CIDR", "1.2.3.4/24", 0, None, False, "Wrong type"),
+        (False, "CALICO_IPV4POOL_CIDR", "fd00::/24", 0, None, True, "Wrong type"),
+        (True, "CALICO_IPV6POOL_CIDR", "::0:a:b:c:d:e:0/120", 2, None, False, "Valid, non-canonical form"),
+        (False, "CALICO_IPV4POOL_CIDR", "1.2/16", 0, None, True, "Valid, unusual form"),
     ])
-    def test_default_pools(self, success_expected, param, value, exp_num_pools, ipip, description):
+    def test_default_pools(self, success_expected, param, value, exp_num_pools, ipip, nat_outgoing, description):
         """
         Test that the various options for default pools work correctly
         """
@@ -138,7 +138,11 @@ class TestDefaultPools(TestBase):
                 "Didn't find ipip mode in pool %s" % pool
 
         # Check NAT setting
-        assert pool['spec']['nat-outgoing'] is True, "Didn't find nat enabled in pool %s" % pool
+        if param == "CALICO_IPV4POOL_CIDR":
+            assert pool['spec']['nat-outgoing'] is False, "Wrong NAT default value for IPv4 in pool %s" % pool
+        if param == "CALICO_IPV6POOL_CIDR":
+            assert pool['spec']['nat-outgoing'] is False, "Wrong NAT default value for IPv6 in pool %s" % pool
+
 
     def test_no_default_pools(self):
         """


### PR DESCRIPTION
This patch relates to the issue: #1580

It adds the parameter to CALICO_NAT_OUTGOING for the default IPPool creation.
This enables to disable nat-outgoing in the default IPv4 and IPv6 IPPools created.
