### PR TITLE
calico/node: Makefile, always pull alpine

### DIFF
--- a/Makefile.calico-node
+++ b/Makefile.calico-node
@@ -66,7 +66,7 @@ calico-node-latest.aci: calico-node.tar
 
 # Build calico/node docker image - explicitly depend on the container binaries.
 $(NODE_CONTAINER_CREATED): $(NODE_CONTAINER_DIR)/Dockerfile $(NODE_CONTAINER_FILES) $(addprefix $(NODE_CONTAINER_BIN_DIR)/,$(NODE_CONTAINER_BINARIES))
-	docker build -t $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_DIR)
+	docker build --pull -t $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_DIR)
 	touch $@
 
 # Get felix binaries


### PR DESCRIPTION
To ensure that latest alpine release is used