### PR TITLE
[WiP] Add support for network sets.

### DIFF
--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -118,6 +118,10 @@ func getResourceFromArguments(args map[string]interface{}) (unversioned.Resource
 		h.Metadata.Workload = workload
 		h.Metadata.Node = node
 		return *h, nil
+	case "networkset", "networksets", "netset", "netsets":
+		n := api.NewNetworkSet()
+		n.Metadata.Name = name
+		return *n, nil
 	case "profile", "profiles", "pro", "pros":
 		p := api.NewProfile()
 		p.Metadata.Name = name
@@ -275,7 +279,7 @@ func executeConfigCommand(args map[string]interface{}, action action) commandRes
 	return results
 }
 
-// execureResourceAction fans out the specific resource action to the appropriate method
+// executeResourceAction fans out the specific resource action to the appropriate method
 // on the ResourceManager for the specific resource.
 func executeResourceAction(args map[string]interface{}, client *client.Client, resource unversioned.Resource, action action) (unversioned.Resource, error) {
 	rm := resourcemgr.GetResourceManager(resource)

--- a/calicoctl/resourcemgr/networkset.go
+++ b/calicoctl/resourcemgr/networkset.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
+	"github.com/projectcalico/libcalico-go/lib/client"
+)
+
+func init() {
+	registerResource(
+		api.NewNetworkSet(),
+		api.NewNetworkSetList(),
+		[]string{"NAME"},
+		[]string{"NAME", "NETS"},
+		map[string]string{
+			"NAME":      "{{.Metadata.Name}}",
+			"NETS":       "{{join .Spec.Nets \",\"}}",
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.NetworkSet)
+			return client.NetworkSets().Apply(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.NetworkSet)
+			return client.NetworkSets().Create(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.NetworkSet)
+			return client.NetworkSets().Update(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.NetworkSet)
+			return nil, client.NetworkSets().Delete(r.Metadata)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.NetworkSet)
+			return client.NetworkSets().List(r.Metadata)
+		},
+	)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 91a8d9a89a8e34c483b837ccd059cb40ebcea88394a9e6d9360425a749a0c7f2
-updated: 2017-06-07T11:17:07.316190432-07:00
+hash: f4f6f5f10abb4cef746bdbe0931f9013b0d119d445d87c902ddbcfb0c5b6f9a4
+updated: 2017-06-22T14:54:30.095269826+01:00
 imports:
 - name: github.com/armon/go-radix
   version: 4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
@@ -152,7 +152,8 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 73241603bc62d6e7a94582f06327ac661bb6ecdc
+  version: 5feddba03da6cda6155c567a13cd37c4a1caa432
+  repo: https://github.com/fasaxc/libcalico-go.git
   subpackages:
   - lib/api
   - lib/api/unversioned

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,7 +23,8 @@ import:
   version: 17ae440991da3bdb2df4309936dd2074f66ec394
 - package: github.com/projectcalico/go-yaml-wrapper
 - package: github.com/projectcalico/libcalico-go
-  version: v1.4.1
+  repo: https://github.com/fasaxc/libcalico-go.git
+  version: cidr-group
   subpackages:
   - lib/api
   - lib/api/unversioned

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -127,6 +127,16 @@ class TestCreateFromFile(TestBase):
                      'profiles': ['prof1',
                                   'prof2']}
         }),
+        ("netSet1", {
+            'apiVersion': 'v1',
+            'kind': 'networkSet',
+            'metadata': {'labels': {'type': 'frontend'},
+                         'name': 'netset1'},
+            'spec': {'nets': [
+                "10.0.0.0/16",
+                "12.0.0.0/24",
+            ]}
+        }),
         ("policy1", {'apiVersion': 'v1',
                      'kind': 'policy',
                      'metadata': {'name': 'policy1'},


### PR DESCRIPTION
## Description
Add support for network sets in calicoctl.

## Todos
- [ ] Update libcalico-go pin when libcalico-go change is merged
- [x] Tests
- [ ] Documentation

