### PR TITLE
Report error and exit when non-default config file is missing.

### DIFF
--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -42,7 +42,7 @@ Options:
                             "-" loads from stdin.
   -c --config=<CONFIG>      Path to the file containing connection
                             configuration in YAML or JSON format.
-                            [default: /etc/calico/calicoctl.cfg]
+                            [default: ` + constants.DefaultConfigPath + `]
 
 Description:
   The apply command is used to create or replace a set of resources by filename

--- a/calicoctl/commands/clientmgr/client.go
+++ b/calicoctl/commands/clientmgr/client.go
@@ -15,9 +15,11 @@
 package clientmgr
 
 import (
+	"fmt"
 	"os"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/client"
 )
@@ -45,7 +47,11 @@ func NewClient(cf string) (*client.Client, error) {
 // otherwise will load from environment variables.
 func LoadClientConfig(cf string) (*api.CalicoAPIConfig, error) {
 	if _, err := os.Stat(cf); err != nil {
-		log.Infof("Config file cannot be read - reading config from environment")
+		if (cf != constants.DefaultConfigPath) {
+			fmt.Printf("Error reading config file: %s\n", cf)
+			os.Exit(1)
+		}
+		log.Infof("Config file: %s cannot be read - reading config from environment", cf)
 		cf = ""
 	}
 

--- a/calicoctl/commands/config.go
+++ b/calicoctl/commands/config.go
@@ -63,7 +63,7 @@ Options:
                         expected.
   -c --config=<CONFIG>  Path to the file containing connection configuration in
                         YAML or JSON format.
-                        [default: /etc/calico/calicoctl.cfg]
+                        [default: ` + constants.DefaultConfigPath + `]
 
 Description:
 

--- a/calicoctl/commands/constants/help.go
+++ b/calicoctl/commands/constants/help.go
@@ -19,4 +19,5 @@ const (
 or supply details in a config file.
 
 `
+	DefaultConfigPath = "/etc/calico/calicoctl.cfg"
 )

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -44,7 +44,7 @@ Options:
                             create an entry that already exists.
   -c --config=<CONFIG>      Path to the file containing connection
                             configuration in YAML or JSON format.
-                            [default: /etc/calico/calicoctl.cfg]
+                            [default: ` + constants.DefaultConfigPath + `]
 
 Description:
   The create command is used to create a set of resources by filename or stdin.

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -59,7 +59,7 @@ Options:
                             node-specific.
   -c --config=<CONFIG>      Path to the file containing connection
                             configuration in YAML or JSON format.
-                            [default: /etc/calico/calicoctl.cfg]
+                            [default: ` + constants.DefaultConfigPath + `]
 
 Description:
   The delete command is used to delete a set of resources by filename or stdin,

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -58,7 +58,7 @@ Options:
                                peer or node-specific.
   -c --config=<CONFIG>         Path to the file containing connection
                                configuration in YAML or JSON format.
-                               [default: /etc/calico/calicoctl.cfg]
+                               [default: ` + constants.DefaultConfigPath + `]
 
 Description:
   The get command is used to display a set of resources by filename or stdin,

--- a/calicoctl/commands/ipam/release.go
+++ b/calicoctl/commands/ipam/release.go
@@ -37,7 +37,7 @@ Options:
      --ip=<IP>          IP address to release.
   -c --config=<CONFIG>  Path to the file containing connection configuration in
                         YAML or JSON format.
-                        [default: /etc/calico/calicoctl.cfg]
+                        [default: ` + constants.DefaultConfigPath + `]
 
 Description:
   The ipam release command releases an IP address from the Calico IP Address

--- a/calicoctl/commands/ipam/show.go
+++ b/calicoctl/commands/ipam/show.go
@@ -36,7 +36,7 @@ Options:
      --ip=<IP>          IP address to show.
   -c --config=<CONFIG>  Path to the file containing connection configuration in
                         YAML or JSON format.
-                        [default: /etc/calico/calicoctl.cfg]
+                        [default: ` + constants.DefaultConfigPath + `]
 
 Description:
   The ipam show command prints information about a given IP address, such as

--- a/calicoctl/commands/node/run.go
+++ b/calicoctl/commands/node/run.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docopt/docopt-go"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
+	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/net"
 )
@@ -155,7 +156,7 @@ Options:
                            and Calico profiles are disabled.
   -c --config=<CONFIG>     Path to the file containing connection
                            configuration in YAML or JSON format.
-                           [default: /etc/calico/calicoctl.cfg]
+                           [default: ` + constants.DefaultConfigPath + `]
 
 Description:
   This command is used to start a calico/node container instance which provides

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -43,7 +43,7 @@ Options:
                              to "-" loads from stdin.
   -c --config=<CONFIG>       Path to the file containing connection
                              configuration in YAML or JSON format.
-                             [default: /etc/calico/calicoctl.cfg]
+                             [default: ` + constants.DefaultConfigPath + `]
 
 Description:
   The replace command is used to replace a set of resources by filename or


### PR DESCRIPTION
## Description
Print an error and exit when non-default config file is missing. Error only when the user specifies a non-default ("/etc/calico/calicoctl.cfg") config file via --config= option.

Issue: https://github.com/projectcalico/calicoctl/issues/1678

## Testing
* Manually tested all commands with the following scenarios:
  * Valid /etc/calico/calicoctl.cfg file
  * Missing /etc/calico/calicoctl.cfg file
  * Valid non-default config file (e.g. fun.yaml)
  * Missing non-default config file
