### PR TITLE
Remove CALICO_LIBNETWORK* env variables when they're set to default values

### DIFF
--- a/calicoctl/commands/node/run.go
+++ b/calicoctl/commands/node/run.go
@@ -42,6 +42,7 @@ const (
 	AUTODETECTION_METHOD_CAN_REACH      = "can-reach="
 	AUTODETECTION_METHOD_INTERFACE      = "interface="
 	AUTODETECTION_METHOD_SKIP_INTERFACE = "skip-interface="
+	DEFAULT_DOCKER_IFPREFIX             = "cali"
 )
 
 var (
@@ -146,7 +147,7 @@ Options:
                            Interface prefix to use for the network interface
                            within the Docker containers that have been networked
                            by the Calico driver.
-                           [default: cali]
+                           [default: ` + DEFAULT_DOCKER_IFPREFIX + `]
      --use-docker-networking-container-labels
                            Extract the Calico-namespaced Docker container labels
                            (org.projectcalico.label.*) and apply them to the
@@ -249,8 +250,6 @@ Description:
 		"NODENAME":                          name,
 		"CALICO_NETWORKING_BACKEND":         backend,
 		"CALICO_LIBNETWORK_ENABLED":         fmt.Sprint(!disableDockerNw),
-		"CALICO_LIBNETWORK_CREATE_PROFILES": fmt.Sprint(!useDockerContainerLabels),
-		"CALICO_LIBNETWORK_LABEL_ENDPOINTS": fmt.Sprint(useDockerContainerLabels),
 	}
 
 	// Validate the ifprefix to only allow alphanumeric characters
@@ -264,12 +263,16 @@ Description:
 		os.Exit(1)
 	}
 
-	// Set CALICO_LIBNETWORK_IFPREFIX env variable if Docker network is enabled.
-	if !disableDockerNw {
+	// Set CALICO_LIBNETWORK_IFPREFIX env variable if Docker network is enabled and set to non-default value.
+	if !disableDockerNw && ifprefix != DEFAULT_DOCKER_IFPREFIX {
 		envs["CALICO_LIBNETWORK_IFPREFIX"] = ifprefix
 	}
 
 	// Add in optional environments.
+	if useDockerContainerLabels {
+		envs["CALICO_LIBNETWORK_CREATE_PROFILES"] = "false"
+		envs["CALICO_LIBNETWORK_LABEL_ENDPOINTS"] = "true"
+	}
 	if nopools {
 		envs["NO_DEFAULT_POOLS"] = "true"
 	}


### PR DESCRIPTION
## Description

See issue: https://github.com/projectcalico/calicoctl/issues/1520

No longer set the following environment variables when they're set to libnetwork-plugin's default:
- CALICO_LIBNETWORK_CREATE_PROFILES (enabled by default in libnetwork-plugin)
- CALICO_LIBNETWORK_LABEL_ENDPOINTS (disabled by default in libnetwork-plugin)
- CALICO_LIBNETWORK_IFPREFIX ("cali" by default in libnetwork-plugin)

## Testing
- Manually validated correct environment values based on appropriate calicoctl flags.
- Validated default values in libnetwork-plugin
- Ran basic docker sanity test to confirm functionality still works