### PR TITLE
Map /run into the container for iptables lockfile.

### DIFF
--- a/calicoctl/commands/node/run.go
+++ b/calicoctl/commands/node/run.go
@@ -300,6 +300,7 @@ Description:
 		{hostPath: logDir, containerPath: "/var/log/calico"},
 		{hostPath: "/var/run/calico", containerPath: "/var/run/calico"},
 		{hostPath: "/lib/modules", containerPath: "/lib/modules"},
+		{hostPath: "/run", containerPath: "/run"},
 	}
 
 	if !disableDockerNw {


### PR DESCRIPTION
## Description
Felix now supports taking the iptables lock, which is file-based so it needs to be mapped into the container.

## Todos
- [ ] Tests
- [ ] Documentation

