### PR TITLE
Report version and cluster type from datastore in version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ LOCAL_USER_ID?=$(shell id -u $$USER)
 PACKAGE_NAME?=github.com/projectcalico/calicoctl
 
 LDFLAGS=-ldflags "-X $(PACKAGE_NAME)/calicoctl/commands.VERSION=$(CALICOCTL_VERSION) \
-	-X $(PACKAGE_NAME)/calicoctl/calicoctl/commands.BUILD_DATE=$(CALICOCTL_BUILD_DATE) \
+	-X $(PACKAGE_NAME)/calicoctl/commands.BUILD_DATE=$(CALICOCTL_BUILD_DATE) \
 	-X $(PACKAGE_NAME)/calicoctl/commands.GIT_REVISION=$(CALICOCTL_GIT_REVISION) -s -w"
 
 LIBCALICOGO_PATH?=none


### PR DESCRIPTION
## Description
As title says.
Also fixed build date in the Makefile so it is set properly.

## Todos
- [ ] Documentation
- [x] Release note

## Release Note
```release-note
The calicoctl version command now includes the CalicoVersion and ClusterType as retrieved from the datastore.
```
