### PR TITLE
Remove LIBCALICOGO_VER from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,6 @@ ARCH := amd64
 ###############################################################################
 # Subcomponent versions:
 GO_BUILD_VER:=latest
-# Set libcalico-go version in glide.yaml first then do a `glide up -v` to update glide.lock.
-# Setting LIBCALICOGO_VER in the Makefile won't update the glide dependencies.
-LIBCALICOGO_VER := v1.2.1
 ###############################################################################
 
 CALICOCTL_VERSION?=$(shell git describe --tags --dirty --always)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,10 +14,10 @@ Creating a new release creates the following artifacts:
 1. Make sure you are on the master branch and don't have any local uncommitted changes. e.g. Update the libcalico-go pin to the latest release in `glide.yaml` and run `glide up -v`, create PR, ensure test pass and merge.
 
 2. Pre-requisites for pushing container images:
-   - Make sure you have write access to calico orgs on Dockerhub and quay.io. 
+   - Make sure you have write access to calico orgs on Dockerhub and quay.io.
    - Login using your dockerhub credentials.
-   - `docker login` in your terminal. 
-   - For quay.io: 
+   - `docker login` in your terminal.
+   - For quay.io:
      1. Go to your account on quay.io
      2. Go to the account settings
      3. Go to the "settings" tab
@@ -27,16 +27,15 @@ Creating a new release creates the following artifacts:
    - Now you should be able to push the container images with `docker push` command.
 
 3. Update the sub-component versions in the Makefile:
-     - `LIBCALICOGO_VER`
      - `GO_BUILD_VER`
 
 4. If build fails during `make release`, make sure git tag is deleted before doing `make release` again. (This can be done with `git tag -d <tag>`)
 
 ## Creating the release
 1. Choose a version e.g. `export VERSION=v1.0.0`
-2. Create the release artifacts repositories `make release VERSION=$VERSION`. 
+2. Create the release artifacts repositories `make release VERSION=$VERSION`.
 3. Follow the instructions to push the artifacts and git tag.
-4. Create a release on Github, using the tag which was just pushed. 
+4. Create a release on Github, using the tag which was just pushed.
 5. Attach the following `calicoctl` binaries:
    - `calicoctl`
    - `calicoctl-darwin-amd64`


### PR DESCRIPTION
## Description

Doesn't looks like this is used anywhere anymore. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
