### PR TITLE
fix node status help typo

### DIFF
--- a/calicoctl/commands/node/status.go
+++ b/calicoctl/commands/node/status.go
@@ -43,7 +43,7 @@ Options:
   -h --help                 Show this screen.
 
 Description:
-  Check the status of the Calico node instance.  This incudes the status and
+  Check the status of the Calico node instance.  This includes the status and
   uptime of the node instance, and BGP peering states.
 `
 


### PR DESCRIPTION
Correct "node status" help typo (incudes->includes)
see issue: https://github.com/projectcalico/calicoctl/issues/1693

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
