### PR TITLE
Update the import for logrus to use lowercasing

### DIFF
--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -19,9 +19,9 @@ import (
 
 	"os"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docopt/docopt-go"
 	"github.com/projectcalico/calicoctl/calicoctl/commands"
+	log "github.com/sirupsen/logrus"
 )
 
 func main() {

--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -19,8 +19,8 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docopt/docopt-go"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 )

--- a/calicoctl/commands/clientmgr/client.go
+++ b/calicoctl/commands/clientmgr/client.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/client"
+	log "github.com/sirupsen/logrus"
 )
 
 // NewClient creates a new CalicoClient using connection information in the specified
@@ -47,7 +47,7 @@ func NewClient(cf string) (*client.Client, error) {
 // otherwise will load from environment variables.
 func LoadClientConfig(cf string) (*api.CalicoAPIConfig, error) {
 	if _, err := os.Stat(cf); err != nil {
-		if (cf != constants.DefaultConfigPath) {
+		if cf != constants.DefaultConfigPath {
 			fmt.Printf("Error reading config file: %s\n", cf)
 			os.Exit(1)
 		}

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -19,8 +19,8 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docopt/docopt-go"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 )

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -19,8 +19,8 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docopt/docopt-go"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 )

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	log "github.com/sirupsen/logrus"
 )
 
 func Get(args []string) {

--- a/calicoctl/commands/node/checksystem.go
+++ b/calicoctl/commands/node/checksystem.go
@@ -23,9 +23,9 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	docopt "github.com/docopt/docopt-go"
 	goversion "github.com/mcuadros/go-version"
+	log "github.com/sirupsen/logrus"
 )
 
 // The minimum allowed linux kernel version is 2.6.24, which introduced network

--- a/calicoctl/commands/node/diags.go
+++ b/calicoctl/commands/node/diags.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docopt/docopt-go"
+	log "github.com/sirupsen/logrus"
 	shutil "github.com/termie/go-shutil"
 )
 

--- a/calicoctl/commands/node/run.go
+++ b/calicoctl/commands/node/run.go
@@ -25,13 +25,13 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docopt/docopt-go"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/net"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -247,9 +247,9 @@ Description:
 
 	// Create a mapping of environment variables to values.
 	envs := map[string]string{
-		"NODENAME":                          name,
-		"CALICO_NETWORKING_BACKEND":         backend,
-		"CALICO_LIBNETWORK_ENABLED":         fmt.Sprint(!disableDockerNw),
+		"NODENAME":                  name,
+		"CALICO_NETWORKING_BACKEND": backend,
+		"CALICO_LIBNETWORK_ENABLED": fmt.Sprint(!disableDockerNw),
 	}
 
 	// Validate the ifprefix to only allow alphanumeric characters

--- a/calicoctl/commands/node/status.go
+++ b/calicoctl/commands/node/status.go
@@ -26,12 +26,12 @@ import (
 
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docopt/docopt-go"
 	gops "github.com/mitchellh/go-ps"
 	"github.com/olekukonko/tablewriter"
 	gobgp "github.com/osrg/gobgp/client"
 	"github.com/osrg/gobgp/packet/bgp"
+	log "github.com/sirupsen/logrus"
 )
 
 // Status prints status of the node and returns error (if any)
@@ -310,7 +310,7 @@ func scanBIRDPeers(ipv string, conn net.Conn) ([]bgpPeer, error) {
 
 // printGoBGPPeers queries GoBGP and displays the local peers in table format.
 func printGoBGPPeers(ipv string) {
-	client, err := gobgp.NewGoBGPClient("")
+	client, err := gobgp.New("")
 	if err != nil {
 		fmt.Printf("Error creating gobgp client: %s\n", err)
 		os.Exit(1)

--- a/calicoctl/commands/printer.go
+++ b/calicoctl/commands/printer.go
@@ -25,12 +25,12 @@ import (
 	"text/tabwriter"
 	"text/template"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/calicoctl/calicoctl/resourcemgr"
 	"github.com/projectcalico/go-json/json"
 	"github.com/projectcalico/go-yaml-wrapper"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/client"
+	log "github.com/sirupsen/logrus"
 )
 
 type resourcePrinter interface {

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -22,8 +22,8 @@ import (
 
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	log "github.com/sirupsen/logrus"
 )
 
 func Replace(args []string) {

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/resourcemgr"
@@ -32,6 +31,7 @@ import (
 	calicoErrors "github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/scope"
+	log "github.com/sirupsen/logrus"
 )
 
 type action int

--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -23,12 +23,12 @@ import (
 	"reflect"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	yamlsep "github.com/projectcalico/calicoctl/calicoctl/util/yaml"
 	"github.com/projectcalico/go-yaml-wrapper"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/client"
 	"github.com/projectcalico/libcalico-go/lib/validator"
+	log "github.com/sirupsen/logrus"
 )
 
 // The ResourceManager interface provides useful function for each resource type.  This includes:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 202ed42a2f5c98774750abe7ec6592c450f31cb125abc39c54d913dee452e9d4
-updated: 2017-07-27T17:11:46.516911671-07:00
+hash: ff19506554f8da1b208f548c05b167cd70545147eb764ec944ad22cb37746a2b
+updated: 2017-08-03T11:16:34.693140309-07:00
 imports:
 - name: github.com/armon/go-radix
   version: 4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
@@ -37,7 +37,7 @@ imports:
   - log
   - swagger
 - name: github.com/fsnotify/fsnotify
-  version: 4da3e2cfbabc9f751898f250b49f2439785783a1
+  version: a904159b9206978bb6d53fcc7a769e5cd726c737
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-openapi/jsonpointer
@@ -63,7 +63,7 @@ imports:
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/hashicorp/hcl
-  version: 392dba7d905ed5d04a5794ba89f558b27e2ba1ca
+  version: 630949a3c5fa3c613328e1b8256052cbc2327c9b
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -78,7 +78,7 @@ imports:
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/influxdata/influxdb
-  version: 62534ce5c1fcb1e7e3962210d74a44917a68381a
+  version: c83c742b49f2a22ab997081c19ea0fb44f2bb8fc
   subpackages:
   - client/v2
   - models
@@ -86,9 +86,9 @@ imports:
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
-  version: f611eb38b3875cc3bd991ca91c51d06446afa14c
+  version: 91921eb4cf999321cdbeebdba5a03555800d493b
 - name: github.com/magiconair/properties
-  version: be5ece7dd465ab0765a9682137865547526d1dfb
+  version: b3b15ef068fd0b17ddf408a23669f20811d194d2
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -96,15 +96,15 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/mattn/go-runewidth
-  version: 97311d9f7767e3d6f422ea06661bc2c7a19e8a5d
+  version: 14207d285c6c197daabb5c9793d63e7af9ab2d50
 - name: github.com/mcuadros/go-version
   version: 257f7b9a7d87427c8d7f89469a5958d57f8abd7c
 - name: github.com/mitchellh/go-ps
-  version: 4fdf99ab29366514c69ccccddab5dc58b8d84062
+  version: e2d21980687ce16e58469d98dcee92d27fbbd7fb
 - name: github.com/mitchellh/mapstructure
-  version: d0303fe809921458f417bcf828397a65db30a7e4
+  version: db1efb556f84b25a0a13a04aad883943538ad2e0
 - name: github.com/olekukonko/tablewriter
-  version: be5337e7b39e64e5f91445ce7e721888dbab7387
+  version: febf2d34b54a69ce7530036c7503b1c9fbfdf0bb
 - name: github.com/onsi/ginkgo
   version: f40a49d81e5c12e90400620b6242fb29a8e7c9d9
   subpackages:
@@ -127,7 +127,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/osrg/gobgp
-  version: 38c47609a2eeae67c2c9cc042adea60484c2f481
+  version: bbd1d99396fef6503e308d1851ecf91c31006635
   subpackages:
   - api
   - client
@@ -139,8 +139,10 @@ imports:
   - server
   - table
   - zebra
+- name: github.com/pelletier/go-buffruneio
+  version: c37440a7cf42ac63b919c752ca73a85067e05992
 - name: github.com/pelletier/go-toml
-  version: 69d355db5304c0f7f809a2edc054553e7142f016
+  version: 361678322880708ac144df8575e6f01144ba1404
 - name: github.com/projectcalico/go-json
   version: 6219dc7339ba20ee4c57df0a8baac62317d19cb1
   subpackages:
@@ -150,7 +152,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 73b7a646d0d29d01ff0a63ea5b03beac0906ea7c
+  version: 93f9e49214a678551648eb9c28ce57bc286a3169
   subpackages:
   - lib/api
   - lib/api/unversioned
@@ -181,21 +183,21 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
-- name: github.com/Sirupsen/logrus
+  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
+- name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/afero
   version: 9be650865eab0c12963d8753212f4f9c66cdcf12
   subpackages:
   - mem
 - name: github.com/spf13/cast
-  version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
+  version: f820543c3592e283e311a60d2a600a664e39f6f7
 - name: github.com/spf13/jwalterweatherman
-  version: 0efa5202c04663c757d84f90f5219c1250baf94f
+  version: fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66
 - name: github.com/spf13/pflag
   version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
 - name: github.com/spf13/viper
-  version: df7314a14e26fea5443bb6e696b207d14d9a266d
+  version: 7538d73b4eb9511d85a9f1dfef202eeb8ac260f4
 - name: github.com/termie/go-shutil
   version: bcacb06fecaeec8dc42af03c87c6949f4a05c74c
 - name: github.com/ugorji/go
@@ -207,7 +209,7 @@ imports:
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: 8ba1072b58e0c2a240eb5f6120165c7776c3e7b8
+  version: 54f0e4339ce73702a0607f49922aaa1e749b418d
 - name: golang.org/x/crypto
   version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,14 +5,14 @@ owners:
 - name: Rob Brockbank
   email: rob@tigera.io
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: ^0.10.0
 - package: github.com/docopt/docopt-go
 - package: github.com/mcuadros/go-version
 - package: github.com/mitchellh/go-ps
 - package: github.com/olekukonko/tablewriter
 - package: github.com/osrg/gobgp
-  version: 38c47609a2eeae67c2c9cc042adea60484c2f481
+  version: v1.22
   subpackages:
   - client
   - packet/bgp
@@ -23,7 +23,7 @@ import:
   version: 17ae440991da3bdb2df4309936dd2074f66ec394
 - package: github.com/projectcalico/go-yaml-wrapper
 - package: github.com/projectcalico/libcalico-go
-  version: ^1.5.0
+  version: 93f9e49214a678551648eb9c28ce57bc286a3169
   subpackages:
   - lib/api
   - lib/api/unversioned


### PR DESCRIPTION
## Description
Updating the logrus import to use the new updated user name (which is lowercased).  This will prevent import errors with vendoring going forward.

Requires https://github.com/projectcalico/libcalico-go/pull/484

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
```release-note
None required
```
