### PR TITLE
Fixed right ipip information for ippools

### DIFF
--- a/calicoctl/resourcemgr/ippool.go
+++ b/calicoctl/resourcemgr/ippool.go
@@ -29,7 +29,7 @@ func init() {
 		map[string]string{
 			"CIDR": "{{.Metadata.CIDR}}",
 			"NAT":  "{{.Spec.NATOutgoing}}",
-			"IPIP": "{{if .Spec.IPIP}}{{.Spec.IPIP.Enabled}}{{else}}false{{end}}",
+			"IPIP": "{{.Spec.IPIP.Mode}}",
 		},
 		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
 			r := resource.(api.IPPool)

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -687,7 +687,7 @@ class TestCreateFromFile(TestBase):
           {'apiVersion': 'v1',
            'kind': 'ipPool',
            'metadata': {'cidr': "10.0.1.0/24"},
-           'spec': {'ipip': {'enabled': 'always'}}
+           'spec': {'ipip': {'mode': 'always'}}
            },
          ),
         ("profile",

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -684,11 +684,6 @@ class TestCreateFromFile(TestBase):
           'metadata': {'cidr': "10.0.1.0/24"},
           'spec': {'ipip': {'enabled': True}}
           },
-          {'apiVersion': 'v1',
-           'kind': 'ipPool',
-           'metadata': {'cidr': "10.0.1.0/24"},
-           'spec': {'ipip': {'mode': 'always'}}
-           },
          ),
         ("profile",
          {'apiVersion': 'v1',


### PR DESCRIPTION
## Description
Fixes #1681
`calicoctl get pool -o wide` will show the ipip mode in the IPIP column.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
