### PR TITLE
Adding support for ppc64le builds.

### DIFF
--- a/calicoctl/Dockerfile.calicoctl
+++ b/calicoctl/Dockerfile.calicoctl
@@ -1,7 +1,7 @@
 FROM alpine:3.4
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
-ADD dist/calicoctl ./calicoctl
+ADD dist/calicoctl-linux-amd64 ./calicoctl
 
 ENV CALICO_CTL_CONTAINER=TRUE
 ENV PATH=$PATH:/

--- a/calicoctl/Dockerfile.calicoctl-ppc64le
+++ b/calicoctl/Dockerfile.calicoctl-ppc64le
@@ -1,0 +1,10 @@
+FROM ppc64le/alpine:3.6
+MAINTAINER Tom Denham <tom@projectcalico.org>
+
+ADD dist/calicoctl-linux-ppc64le ./calicoctl
+
+ENV CALICO_CTL_CONTAINER=TRUE
+ENV PATH=$PATH:/
+
+WORKDIR /root
+ENTRYPOINT ["/calicoctl"]

--- a/calicoctl/Dockerfile.calicoctl.build-ppc64le
+++ b/calicoctl/Dockerfile.calicoctl.build-ppc64le
@@ -1,0 +1,8 @@
+FROM ppc64le/golang:1.8.3
+MAINTAINER Tom Denham <tom@tigera.io>
+
+# These are only required for running the tests in a container.
+RUN go get github.com/onsi/ginkgo/ginkgo
+RUN go get github.com/onsi/gomega
+
+WORKDIR /go/src/github.com/projectcalico/calicoctl


### PR DESCRIPTION
Signed-off-by: David Wilder <wilder@us.ibm.com>

Adding support for ppc64le.

 I ran the following tests and saw no issues:
ARCH=ppc64le make semaphore  (on ppc64)
make semaphore   (on amd64)
ARCH=amd64 make semaphore  (on amd64)
