### PR TITLE
Pin to libcalico-go with KDD Calico Policy support

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fddfa0aafb32340fd19d572139b52a80e5abede1cbe4a0316b57102a3a15ff3a
-updated: 2017-08-25T14:45:46.666523186-07:00
+hash: 5fd3b9ba72e91924d4f799865daacf212928d5b9bec931f07c0a858b881421dc
+updated: 2017-09-22T05:41:22.84924549Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -172,7 +172,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: da18e6e179b08697d589aad3172b241de5e4d8d9
+  version: fb0f93099e89eec0379f2b30e21e8427c8dc952d
   subpackages:
   - lib/api
   - lib/api/unversioned
@@ -180,6 +180,7 @@ imports:
   - lib/backend/api
   - lib/backend/compat
   - lib/backend/etcd
+  - lib/backend/extensions
   - lib/backend/k8s
   - lib/backend/k8s/custom
   - lib/backend/k8s/resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,7 +23,7 @@ import:
   version: 17ae440991da3bdb2df4309936dd2074f66ec394
 - package: github.com/projectcalico/go-yaml-wrapper
 - package: github.com/projectcalico/libcalico-go
-  version: da18e6e179b08697d589aad3172b241de5e4d8d9
+  version: fb0f93099e89eec0379f2b30e21e8427c8dc952d
   subpackages:
   - lib/api
   - lib/api/unversioned


### PR DESCRIPTION
## Description
This PR pins glide to a libcalico-go that has support for manipulating Calico policies.

Tested by manually running through [Advanced Policy Demo](https://docs.projectcalico.org/v2.5/getting-started/kubernetes/tutorials/advanced-policy) in KDD mode.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
calicoctl now supports creating, updating, and deleting Calico policies when deployed using the Kubernetes datastore backend.
```
