### PR TITLE
Do not allow manipulating Network Policy resources using calicoctl

### DIFF
--- a/calicoctl/resourcemgr/policy.go
+++ b/calicoctl/resourcemgr/policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,9 +15,12 @@
 package resourcemgr
 
 import (
+	"strings"
+
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/client"
+	calicoErrors "github.com/projectcalico/libcalico-go/lib/errors"
 )
 
 func init() {
@@ -33,18 +36,42 @@ func init() {
 		},
 		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
 			r := resource.(api.Policy)
+			if strings.HasPrefix(r.Metadata.Name, "knp.default.") {
+				return nil, calicoErrors.ErrorOperationNotSupported{
+					Identifier: r.Metadata.Name,
+					Operation:  "Apply",
+				}
+			}
 			return client.Policies().Apply(&r)
 		},
 		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
 			r := resource.(api.Policy)
+			if strings.HasPrefix(r.Metadata.Name, "knp.default.") {
+				return nil, calicoErrors.ErrorOperationNotSupported{
+					Identifier: r.Metadata.Name,
+					Operation:  "Create",
+				}
+			}
 			return client.Policies().Create(&r)
 		},
 		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
 			r := resource.(api.Policy)
+			if strings.HasPrefix(r.Metadata.Name, "knp.default.") {
+				return nil, calicoErrors.ErrorOperationNotSupported{
+					Identifier: r.Metadata.Name,
+					Operation:  "Update",
+				}
+			}
 			return client.Policies().Update(&r)
 		},
 		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
 			r := resource.(api.Policy)
+			if strings.HasPrefix(r.Metadata.Name, "knp.default.") {
+				return nil, calicoErrors.ErrorOperationNotSupported{
+					Identifier: r.Metadata.Name,
+					Operation:  "Delete",
+				}
+			}
 			return nil, client.Policies().Delete(r.Metadata)
 		},
 		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -954,6 +954,21 @@ class InvalidData(TestBase):
                        'kind': 'policy',
                        'metadata': {'name': 'policy2'},
                        'spec': {'egress': [{'action': 'jumpupanddown',  # invalid action
+                                            'destination': {},
+                                            'protocol': 'tcp',
+                                            'source': {},
+                                            }],
+                                'ingress': [{'action': 'allow',
+                                             'destination': {},
+                                             'protocol': 'udp',
+                                             'source': {}}],
+                                'order': 100000,
+                                'selector': ""}}),
+                   ("policy-NetworkPolicyNameRejected", {
+                       'apiVersion': 'v1',
+                       'kind': 'policy',
+                       'metadata': {'name': 'knp.default.rejectmeplease'},
+                       'spec': {'egress': [{'action': 'allow',
                                             'destination': {},
                                             'protocol': 'tcp',
                                             'source': {},


### PR DESCRIPTION
## Description
Prevent creating or manipulating kubernetes network policy using calicoctl.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
