### PR TITLE
Increase document separator's maximum buffer size to 10MB.

### DIFF
--- a/calicoctl/util/yaml/separator.go
+++ b/calicoctl/util/yaml/separator.go
@@ -20,7 +20,10 @@ import (
 	"io"
 )
 
-const yamlSeparator = "\n---"
+const (
+	yamlSeparator = "\n---"
+	maxDocumentLength = 10 * 1024 * 1024 // 10MB.
+)
 
 type Separator interface {
 	Next() ([]byte, error)
@@ -32,6 +35,7 @@ type YAMLSeparator struct {
 
 func NewYAMLDocumentSeparator(reader io.Reader) Separator {
 	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 1024), maxDocumentLength)
 	scanner.Split(splitYAMLDocument)
 	return &YAMLSeparator{
 		scanner: scanner,

--- a/calicoctl/util/yaml/separator_test.go
+++ b/calicoctl/util/yaml/separator_test.go
@@ -16,6 +16,7 @@ package yaml
 
 import (
 	"bytes"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -56,6 +57,19 @@ var _ = Describe("Test splitYAMLDocument", func() {
 
 	It("should split out and read the first document in multiple documents", func() {
 		ValidateSplitYAMLDocument("abc\n---\ndef", true, "abc", 8)
+	})
+
+	It("should split out and read the first document in a large doc without separators", func() {
+		// Just shy of 10MB, which is the limit:
+		doc := strings.Repeat("0123456789abcdef", 65535)
+		ValidateSplitYAMLDocument(doc, true, doc, len(doc))
+	})
+
+	It("should split out and read the first document in a compound large doc", func() {
+		// Just shy of 10MB, which is the limit:
+		firstDoc := strings.Repeat("0123456789abcdef", 65535)
+		docs := firstDoc + "\n---\ndef"
+		ValidateSplitYAMLDocument(docs, true, firstDoc, len(firstDoc)+5)
 	})
 
 	It("should read the rest of the multiple documents at the EOF", func() {


### PR DESCRIPTION
## Description

This is a quick fix for #1722.  It simply increases the buffer size to allow a much larger document.

Fixes #1722

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
