### PR TITLE
Metadata handling for immutable fields

### DIFF
--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -65,7 +65,6 @@ Description:
 
     * bgpConfiguration
     * bgpPeer
-    * clusterInformation
     * felixConfiguration
     * globalNetworkPolicy
     * hostEndpoint

--- a/calicoctl/commands/node/run.go
+++ b/calicoctl/commands/node/run.go
@@ -312,11 +312,7 @@ Description:
 			vol{hostPath: "/var/run/docker.sock", containerPath: "/var/run/docker.sock"})
 	}
 
-	if etcdcfg.EtcdEndpoints == "" {
-		envs["ETCD_ENDPOINTS"] = etcdcfg.EtcdScheme + "://" + etcdcfg.EtcdAuthority
-	} else {
-		envs["ETCD_ENDPOINTS"] = etcdcfg.EtcdEndpoints
-	}
+	envs["ETCD_ENDPOINTS"] = etcdcfg.EtcdEndpoints
 	if etcdcfg.EtcdCACertFile != "" {
 		envs["ETCD_CA_CERT_FILE"] = ETCD_CA_CERT_NODE_FILE
 		vols = append(vols, vol{hostPath: etcdcfg.EtcdCACertFile, containerPath: ETCD_CA_CERT_NODE_FILE})

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 57c26af2d28b80040a21b38eea37bd4b70e946dc839f2137d5390657af4614bd
-updated: 2017-10-27T14:16:32.890007-07:00
+hash: bc006be1f71e306bae56a3fd5f5487c2cce7255d22a81941f84f41acc6ca812f
+updated: 2017-11-01T19:01:43.871129953-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -191,6 +191,8 @@ imports:
   - server
   - table
   - zebra
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/pelletier/go-toml
   version: 4e9e0ee19b60b13eb79915933f44d8ed5f268bdd
 - name: github.com/peterbourgon/diskv
@@ -204,7 +206,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: dae320cd652b66d908eb5d59209717e3c3514c26
+  version: dae5f7c41e68cbf278abd2c2a46af904e011a835
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -351,7 +353,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 6c6dac0277229b9e9578c5ca3f74a4345d35cdc2
+  version: 4df58c811fe2e65feb879227b2b245e4dc26e7ad
   subpackages:
   - admissionregistration/v1alpha1
   - apps/v1beta1
@@ -413,6 +415,7 @@ imports:
   - pkg/util/net
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,7 +28,7 @@ import:
   - ssh/terminal
 - package: github.com/projectcalico/go-yaml-wrapper
 - package: github.com/projectcalico/libcalico-go
-  version: dae320cd652b66d908eb5d59209717e3c3514c26
+  version: dae5f7c41e68cbf278abd2c2a46af904e011a835
   subpackages:
   - lib/apis/v2
   - lib/clientv2

--- a/tests/st/utils/data.py
+++ b/tests/st/utils/data.py
@@ -289,6 +289,26 @@ hostendpoint_name1_rev2 = {
     }
 }
 
+hostendpoint_name1_rev3 = {
+    'apiVersion': API_VERSION,
+    'kind': 'HostEndpoint',
+    'metadata': {
+        'name': 'endpoint1',
+        'labels': {'type': 'frontend', 'misc': 'version1'},
+        'annotations': {'key': 'value'},
+        'selfLink': 'test-self-link',
+        'uid': 'test-uid-change',
+        'generation': 3,
+        'finalizers': ['finalizer1', 'finalizer2'],
+        'creationTimestamp': '2006-01-02T15:04:05Z',
+    },
+    'spec': {
+        'interfaceName': 'cali7',
+        'profiles': ['prof1', 'prof2'],
+        'node': 'host2'
+    }
+}
+
 #
 # Profiles
 #


### PR DESCRIPTION
## Description
Added the handling for metadata fields that are populated by the datastore so they should not be overwritten by any calicoctl operations. The fields that are the exception to this rule is `Labels` and `Annotations`.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
