### PR TITLE
re-add st dependency to test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 .PHONY: all binary test clean help
 default: help
-all: test                                               ## Run all the tests
-test: test-containerized                             ## Run all the tests
-all: dist/calicoctl dist/calicoctl-darwin-amd64 dist/calicoctl-windows-amd64.exe test-containerized
+all: dist/calicoctl dist/calicoctl-darwin-amd64 dist/calicoctl-windows-amd64.exe test
+test: test-containerized st                             ## Run all the tests
 
 ###############################################################################
 # calicoctl build

--- a/README.md
+++ b/README.md
@@ -67,10 +67,5 @@ Tests can be run in a container to ensure all build dependencies are met.
 
 To run the tests
 ```
-make ut
-```
-
-To run the tests in a container
-```
-make test-containerized
+make test
 ```


### PR DESCRIPTION
## Description
Restore the `st` dependency on the `test` target. The intent is to have a single target to run prior to pushing a commit.

## Todos
- [X] Tests

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
