### PR TITLE
Change namespace output to more closely match K8s

### DIFF
--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 
 	log "github.com/sirupsen/logrus"
@@ -117,6 +118,11 @@ Description:
 		return
 	}
 
+	printNamespace := false
+	if argutils.ArgBoolOrFalse(parsedArgs, "--all-namespaces") || argutils.ArgStringOrBlank(parsedArgs, "--namespace") != "" {
+		printNamespace = true
+	}
+
 	var rp resourcePrinter
 	output := parsedArgs["--output"].(string)
 	switch output {
@@ -125,9 +131,9 @@ Description:
 	case "json":
 		rp = resourcePrinterJSON{}
 	case "ps":
-		rp = resourcePrinterTable{wide: false}
+		rp = resourcePrinterTable{wide: false, printNamespace: printNamespace}
 	case "wide":
-		rp = resourcePrinterTable{wide: true}
+		rp = resourcePrinterTable{wide: true, printNamespace: printNamespace}
 	default:
 		// Output format may be a key=value pair, so split on "=" to find out.  Pull
 		// out the key and value, and split the value by "," as some options allow

--- a/calicoctl/commands/printer.go
+++ b/calicoctl/commands/printer.go
@@ -88,6 +88,10 @@ type resourcePrinterTable struct {
 	// Wide format.  When headings have not been explicitly specified, this is used to
 	// determine whether to the resource-specific default wide or narrow headings.
 	wide bool
+
+	// Namespace included. When a resource being printed is namespaced, this is used
+	// to determine if the namespace column should be printed or not.
+	printNamespace bool
 }
 
 func (r resourcePrinterTable) print(client client.Interface, resources []runtime.Object) error {
@@ -104,7 +108,7 @@ func (r resourcePrinterTable) print(client client.Interface, resources []runtime
 		}
 
 		// Look up the template string for the specific resource type.
-		tpls, err := rm.GetTableTemplate(headings)
+		tpls, err := rm.GetTableTemplate(headings, r.printNamespace)
 		if err != nil {
 			return err
 		}

--- a/calicoctl/resourcemgr/networkpolicy.go
+++ b/calicoctl/resourcemgr/networkpolicy.go
@@ -29,7 +29,8 @@ func init() {
 		true,
 		[]string{"networkpolicy", "networkpolicies", "policy", "np", "policies", "pol", "pols"},
 		[]string{"NAME"},
-		[]string{"NAME", "ORDER", "SELECTOR", "NAMESPACE"},
+		[]string{"NAME", "ORDER", "SELECTOR"},
+		// NAMESPACE may be prepended in GrabTableTemplate so needs to remain in the map below
 		map[string]string{
 			"NAME":      "{{.ObjectMeta.Name}}",
 			"NAMESPACE": "{{.ObjectMeta.Namespace}}",

--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -44,7 +44,7 @@ import (
 //	-  Commands to manage resource instances through an un-typed interface.
 type ResourceManager interface {
 	GetTableDefaultHeadings(wide bool) []string
-	GetTableTemplate(columns []string) (string, error)
+	GetTableTemplate(columns []string, printNamespace bool) (string, error)
 	GetObjectType() reflect.Type
 	IsNamespaced() bool
 	Apply(ctx context.Context, client client.Interface, resource ResourceObject) (ResourceObject, error)
@@ -467,7 +467,10 @@ func (rh resourceHelper) GetTableDefaultHeadings(wide bool) []string {
 // GetTableTemplate constructs the go-lang template string from the supplied set of headings.
 // The template separates columns using tabs so that a tabwriter can be used to pretty-print
 // the table.
-func (rh resourceHelper) GetTableTemplate(headings []string) (string, error) {
+func (rh resourceHelper) GetTableTemplate(headings []string, printNamespace bool) (string, error) {
+	if _, ok := rh.headingsMap["NAMESPACE"]; printNamespace && ok {
+		headings = append([]string{"NAMESPACE"}, headings...)
+	}
 	// Write the headings line.
 	buf := new(bytes.Buffer)
 	for _, heading := range headings {

--- a/calicoctl/resourcemgr/workloadendpoint.go
+++ b/calicoctl/resourcemgr/workloadendpoint.go
@@ -29,7 +29,8 @@ func init() {
 		true,
 		[]string{"workloadendpoint", "workloadendpoints", "wep", "weps"},
 		[]string{"NAME", "NODE", "WORKLOAD", "INTERFACE"},
-		[]string{"NAME", "NODE", "NAMESPACE", "WORKLOAD", "NETWORKS", "INTERFACE", "PROFILES", "NATS"},
+		[]string{"NAME", "NODE", "WORKLOAD", "NETWORKS", "INTERFACE", "PROFILES", "NATS"},
+		// NAMESPACE may be prepended in GrabTableTemplate so needs to remain in the map below
 		map[string]string{
 			"NAME":         "{{.ObjectMeta.Name}}",
 			"NAMESPACE":    "{{.ObjectMeta.Namespace}}",


### PR DESCRIPTION
Print namespaces as the first column.
Only print namespace column if getting 'all-namespaces' or a specific namespace.

```release-note
None required
```
