### PR TITLE
Add the export option in calicoctl to allow users to be able to apply calicoctl get output

### DIFF
--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -32,7 +32,7 @@ func Get(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl get ( (<KIND> [<NAME>]) |
                 --filename=<FILENAME>)
-                [--output=<OUTPUT>] [--config=<CONFIG>] [--namespace=<NS>] [--all-namespaces]
+                [--output=<OUTPUT>] [--config=<CONFIG>] [--namespace=<NS>] [--all-namespaces] [--export]
 
 Examples:
   # List all policy in default output format.
@@ -55,6 +55,9 @@ Options:
                                Only applicable to NetworkPolicy and WorkloadEndpoint.
                                Uses the default namespace if not specified.
   -a --all-namespaces          If present, list the requested object(s) across all namespaces.
+  --export                     If present, returns the requested object(s) stripped of
+                               cluster-specific information. This flag will be ignored
+			       if <NAME> is not specified.
 
 Description:
   The get command is used to display a set of resources by filename or stdin,

--- a/tests/st/utils/data.py
+++ b/tests/st/utils/data.py
@@ -184,6 +184,59 @@ networkpolicy_name1_rev2 = {
     }
 }
 
+networkpolicy_name2_rev1 = {
+    'apiVersion': API_VERSION,
+    'kind': 'NetworkPolicy',
+    'metadata': {
+        'name': 'policy-mypolicy2',
+        'namespace': 'default',
+        'generateName': 'test-policy-',
+        'deletionTimestamp': '2006-01-02T15:04:07Z',
+        'deletionGracePeriodSeconds': 30,
+        'ownerReferences': [{
+            'apiVersion': 'extensions/v1beta1',
+            'blockOwnerDeletion': True,
+            'controller': True,
+            'kind': 'DaemonSet',
+            'name': 'endpoint1',
+            'uid': 'test-uid-change',
+        }],
+        'initializers': {
+            'pending': [{
+                'name': 'initializer1',
+            }],
+            'result': {
+                'status': 'test-status',
+            },
+        },
+        'clusterName': 'cluster1',
+        'labels': {'label1': 'l1', 'label2': 'l2'},
+        'annotations': {'key': 'value'},
+        'selfLink': 'test-self-link',
+        'uid': 'test-uid-change',
+        'generation': 3,
+        'finalizers': ['finalizer1', 'finalizer2'],
+        'creationTimestamp': '2006-01-02T15:04:05Z',
+    },
+    'spec': {
+        'order': 100000,
+        'selector': "type=='sql'",
+        'types': ['ingress', 'egress'],
+        'egress': [
+            {
+                'action': 'deny',
+                'protocol': 'tcp',
+            },
+        ],
+        'ingress': [
+            {
+                'action': 'allow',
+                'protocol': 'udp',
+            },
+        ],
+    }
+}
+
 #
 # Global Network Policy
 #


### PR DESCRIPTION
## Description
Add the "export" option modeled after the K8s option. This will allow the calicoctl "get" output to be applied without needing modification.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
```release-note
Added --export flag to the calicoctl get command to allow for resources to be applied across clusters strictly from the calicoctl output.
```
