### PR TITLE
Manifests for v1 to v3 migration testing

### DIFF
--- a/test-data/v1/migration/README.md
+++ b/test-data/v1/migration/README.md
@@ -1,0 +1,2 @@
+The test data here is to be used when testing out the offline migration from
+v1 to v3.

--- a/test-data/v1/migration/bgppeer.yaml
+++ b/test-data/v1/migration/bgppeer.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: bgpPeer
+metadata:
+  scope: node
+  node: rack1-host1
+  peerIP: 192.168.1.1
+spec:
+  asNumber: 63400

--- a/test-data/v1/migration/hostendpoint.yaml
+++ b/test-data/v1/migration/hostendpoint.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: hostEndpoint
+metadata:
+  name: eth0
+  node: myhost
+  labels:
+    type: production
+spec:
+  interfaceName: eth0
+  expectedIPs:
+  - 192.168.0.1
+  - 192.168.0.2
+  profiles:
+  - profile1
+  - profile2

--- a/test-data/v1/migration/ippool.yaml
+++ b/test-data/v1/migration/ippool.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ipPool
+metadata:
+  cidr: 10.1.0.0/16
+spec:
+  ipip:
+    enabled: true
+    mode: cross-subnet
+  nat-outgoing: true
+  disabled: false

--- a/test-data/v1/migration/node.yaml
+++ b/test-data/v1/migration/node.yaml
@@ -1,0 +1,10 @@
+## This won't work with KDD
+apiVersion: v1
+kind: node
+metadata:
+  name: node-hostname
+spec:
+  bgp:
+    asNumber: 64512
+    ipv4Address: 10.244.0.1/24
+    ipv6Address: 2001:db8:85a3::8a2e:370:7334/120

--- a/test-data/v1/migration/policy.yaml
+++ b/test-data/v1/migration/policy.yaml
@@ -1,0 +1,77 @@
+## This won't work with KDD
+apiVersion: v1
+kind: policy
+metadata:
+  name: allow-tcp-6379
+  annotations:
+    aname: avalue
+spec:
+  order: 1234
+  selector: role == 'database' && !has(demo)
+  types:
+  - ingress
+  - egress
+  ingress:
+  - action: allow
+    protocol: tcp
+    notProtocol: udplite
+    source:
+      selector: role == 'frontend' && thing not in {'three', 'four'}
+      notSelector: role != 'something' && thing in {'one', 'two'}
+    destination:
+      ports:
+      - 6379
+  - action: allow
+    protocol: tcp
+    source:
+      notSelector: role != 'something' && thing in {'one', 'two'}
+  - action: deny
+    protocol: tcp
+    destination:
+      ports:
+      - 22
+      - 443
+      notPorts:
+      - 80
+  - action: allow
+    source:
+      nets:
+      - "172.18.18.200/32"
+      - "172.18.19.0/24"
+  - action: allow
+    source:
+      net: "172.18.18.100/32"
+  - action: deny
+    source:
+      notNet: "172.19.19.100/32"
+  - action: deny
+    source:
+      notNets:
+      - "172.18.0.0/16"
+  egress:
+  - action: allow
+    protocol: icmp
+    icmp:
+      type: 25
+      code: 25
+
+---
+apiVersion: v1
+kind: policy
+metadata:
+  name: allow-tcp-555-donottrack
+spec:
+  order: 1230
+  selector: role == 'database'
+  types:
+  - ingress
+  ingress:
+  - action: allow
+    protocol: tcp
+    source:
+      selector: role == 'cache'
+    destination:
+      ports:
+      - 555
+  doNotTrack: true
+  preDNAT: false

--- a/test-data/v1/migration/profile.yaml
+++ b/test-data/v1/migration/profile.yaml
@@ -1,0 +1,58 @@
+## This won't work with KDD
+apiVersion: v1
+kind: profile
+metadata:
+  name: profile1
+  labels:
+    profile: profile1 
+  tags:
+  - atag
+  - btag
+spec:
+  ingress:
+  - action: deny
+    protocol: udp
+    source:
+      tag: ctag
+      notTag: dtag
+      net: 172.20.0.0/16
+      notNet: 172.20.5.0/24
+    destination:
+      tag: atag
+      notPorts:
+      - 22
+      - 443
+      - 21
+      - 8080
+  - action: deny
+    protocol: tcp
+    source:
+      nets:
+      - 10.0.20.0/24
+      notNets:
+      - 10.0.20.64/25
+    destination:
+      tag: atag
+      notPorts:
+      - 22
+      - 443
+      - 21
+      - 8080
+  - action: allow
+    protocol: tcp
+    source:
+      selector: profile != 'profile1' && has(role)
+      ports:
+      - 1234
+      - 4567
+      - 8:9
+  egress:
+  - action: allow
+    destination:
+      notSelector: profile == 'system'
+  - action: allow
+    source:
+      selector: something in {'a', 'b'}
+  - action: allow
+    destination:
+      selector: something not in {'a', 'b'}

--- a/test-data/v1/migration/workloadendpoint.yaml
+++ b/test-data/v1/migration/workloadendpoint.yaml
@@ -1,0 +1,18 @@
+## This won't work with KDD
+apiVersion: v1
+kind: workloadEndpoint
+metadata:
+  name: eth0
+  workload: default.frontend-5gs43
+  orchestrator: k8s
+  node: rack1-host1
+  labels:
+    app: frontend
+    calico/k8s_ns: default
+spec:
+  interfaceName: cali0ef24ba
+  mac: ca:fe:1d:52:bb:e9
+  ipNetworks:
+  - 192.168.0.0/32
+  profiles:
+  - profile1


### PR DESCRIPTION
These manifests along with the ones already present in `test-data/v1` should be used to test out the offline migration functionality.

```release-note
None required
```
