### PR TITLE
rename test so it will get picked up and fix assertions

### DIFF
--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -706,29 +706,26 @@ class TestCalicoctlCommands(TestBase):
         rc = calicoctl("delete networkpolicy %s" % name(rev3))
         rc.assert_no_error()
 
-        def test_get(self):
-            """
-            Test that we disallow CRUD on a knp.default prefixed NetworkPolicy.
-            """
-            k8s_np = copy.deepcopy(networkpolicy_name1_rev1)
-            k8s_np['metadata']['name'] = 'knp.default.foobarfizz'
+    def test_disallow_crud_on_knp_defaults(self):
+        """
+        Test that we disallow CRUD on a knp.default prefixed NetworkPolicy.
+        """
+        k8s_np = copy.deepcopy(networkpolicy_name1_rev1)
+        k8s_np['metadata']['name'] = 'knp.default.foobarfizz'
 
-            rc = calicoctl("create", data=k8s_np)
-            rc.assert_error(text=NOT_SUPPORTED)
-            rc.assert_error(text=KUBERNETES_NP)
+        rc = calicoctl("create", data=k8s_np)
+        rc.assert_error(text=NOT_SUPPORTED)
+        rc.assert_error(text=KUBERNETES_NP)
 
-            rc = calicoctl("apply", data=k8s_np)
-            rc.assert_error(text=NOT_SUPPORTED)
-            rc.assert_error(text=KUBERNETES_NP)
+        rc = calicoctl("apply", data=k8s_np)
+        rc.assert_error(text=NOT_FOUND)
 
-            rc = calicoctl("replace", data=k8s_np)
-            rc.assert_error(text=NOT_SUPPORTED)
-            rc.assert_error(text=KUBERNETES_NP)
+        rc = calicoctl("replace", data=k8s_np)
+        rc.assert_error(text=NOT_FOUND)
 
-            rc = calicoctl("delete", data=k8s_np)
-            rc.assert_error(text=NOT_SUPPORTED)
-            rc.assert_error(text=KUBERNETES_NP)
-
+        rc = calicoctl("delete", data=k8s_np)
+        rc.assert_error(text=NOT_SUPPORTED)
+        rc.assert_error(text=KUBERNETES_NP)
 #
 #
 # class TestCreateFromFile(TestBase):


### PR DESCRIPTION
## Description
noticed a duplicate test_method name which wasn't getting run. After making it unique, it was failing so I fixed that up.

```
[success] 6.68% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_namespaced_0: 5.0868s
[success] 6.34% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_5_bgpPeer_unrecognisedfield: 4.8252s
[success] 6.16% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_namespaced_1: 4.6874s
[success] 5.14% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_get: 3.9132s
[success] 3.93% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_6_hostEndpoint_invalidInterface: 2.9934s
[success] 3.59% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_clusterinfo: 2.7347s
[success] 3.42% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_bgpconfig: 2.6029s
[success] 3.07% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_7_policy_invalidHighPortinList: 2.3376s
[success] 2.97% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_metadata_unchanged_0_create: 2.2612s
[success] 2.97% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_json: 2.2594s
[success] 2.89% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_felixconfig: 2.1996s
[success] 2.88% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_replace_with_resource_version: 2.1905s
[success] 2.74% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_stdin: 2.0854s
[success] 2.71% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_export_flag: 2.0592s
[success] 2.60% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_file_multi: 1.9802s
[success] 2.56% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_metadata_unchanged_1_apply: 1.9486s
[success] 2.45% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_apply_with_resource_version: 1.8667s
[success] 2.34% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_delete_with_resource_version: 1.7840s
[success] 2.26% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_file_single_list: 1.7186s
[success] 2.13% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_4_bgpPeer_invalidnodename: 1.6197s
[success] 2.12% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_0: 1.6134s
[success] 1.69% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_4: 1.2839s
[success] 1.69% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_2: 1.2824s
[success] 1.59% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_disallow_crud_on_knp_defaults: 1.2125s
[success] 1.58% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_21_pool_invalidIpIp1: 1.1993s
[success] 1.58% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_3_bgpPeer_invalidIpv6: 1.1990s
[success] 1.48% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_3: 1.1279s
[success] 1.46% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_5: 1.1142s
[success] 1.43% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_1: 1.0870s
[success] 1.33% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_25_compound_config: 1.0120s
[success] 1.33% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_23_profile_ICMPtype: 1.0098s
[success] 0.92% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_2_bgpPeer_apiversion: 0.7013s
[success] 0.81% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_24_profile_ICMPcode: 0.6156s
[success] 0.77% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_22_pool_invalidIpIp2: 0.5895s
[success] 0.76% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_16_pool_invalidNet3: 0.5758s
[success] 0.74% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_17_pool_invalidNet4: 0.5628s
[success] 0.73% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_13_policy_NetworkPolicyNameRejected: 0.5552s
[success] 0.72% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_11_policy_invalidReversedRange: 0.5457s
[success] 0.71% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_0_bgpPeer_invalidASnum: 0.5411s
[success] 0.71% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_15_pool_invalidNet2: 0.5402s
[success] 0.71% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_14_pool_invalidNet1: 0.5376s
[success] 0.71% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_19_pool_invalidNet7: 0.5367s
[success] 0.70% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_18_pool_invalidNet6: 0.5334s
[success] 0.70% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_1_bgpPeer_invalidIP: 0.5298s
[success] 0.68% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_12_policy_invalidAction: 0.5184s
[success] 0.67% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_20_pool_invalidNet8: 0.5108s
[success] 0.66% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_10_policy_invalidLowPortinList: 0.5013s
[success] 0.60% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_9_policy_invalidLowPortinRange: 0.4593s
[success] 0.60% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_8_policy_invalidHighPortinRange: 0.4535s
----------------------------------------------------------------------
Ran 49 tests in 76.127s

OK
```
## Release Note
None required
