### PR TITLE
Add converter FV tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ static-checks: vendor
 SOURCE_DIR?=$(dir $(lastword $(MAKEFILE_LIST)))
 SOURCE_DIR:=$(abspath $(SOURCE_DIR))
 LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 | awk '{print $$7}')
-ST_TO_RUN?=tests/st/calicoctl/test_crud.py
+ST_TO_RUN?=tests/st/calicoctl/
 # Can exclude the slower tests with "-a '!slow'"
 ST_OPTIONS?=
 
@@ -189,6 +189,7 @@ st: dist/calicoctl run-etcd-host
 	           -e MY_IP=$(LOCAL_IP_ENV) \
 	           --rm -t \
 	           -v $(SOURCE_DIR):/code \
+	           -v /var/run/docker.sock:/var/run/docker.sock \
 	           calico/test$(ARCHTAG) \
 	           sh -c 'nosetests $(ST_TO_RUN) -sv --nologcapture  --with-xunit --xunit-file="/code/nosetests.xml" --with-timer $(ST_OPTIONS)'
 

--- a/tests/st/calicoctl/test_upgrade.py
+++ b/tests/st/calicoctl/test_upgrade.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import random
+
+import yaml
+from nose_parameterized import parameterized
+
+from tests.st.utils.utils import calicoctl, \
+    name, wipe_etcd, get_ip, clean_calico_data
+from tests.st.utils.v1_data import data
+
+ETCD_SCHEME = os.environ.get("ETCD_SCHEME", "http")
+ETCD_CA = os.environ.get("ETCD_CA_CERT_FILE", "")
+ETCD_CERT = os.environ.get("ETCD_CERT_FILE", "")
+ETCD_KEY = os.environ.get("ETCD_KEY_FILE", "")
+ETCD_HOSTNAME_SSL = "etcd-authority-ssl"
+
+logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+tests = [
+    ("bgppeer_long_node_name", False),
+    ("bgppeer_dotted_asn", False),
+    ("hep_bad_label", True, "a qualified name must consist of alphanumeric characters"),
+    ("hep_tame", False),
+    ("hep_mixed_ip", False),
+    ("hep_label_too_long", True, "name part must be no more than 63 characters"),
+    ("hep_long_fields", False),
+    ("hep_name_too_long", True, "name is too long by 11 bytes"),
+    ("ippool_mixed", False),
+    ("ippool_v4_small", False),
+    ("ippool_v4_large", False),
+    ("node_long_name", False),
+    ("node_tame", False),
+    ("policy_long_name", False),
+    ("policy_big", False),
+    ("policy_tame", False),
+    ("profile_big", False),
+    ("profile_tame", False),
+    ("wep_bad_workload_id", True, "field must not begin with a '-'"),
+    ("wep_lots_ips", False),
+    ("wep_similar_name", True,
+     "workload was not added through the Calico CNI plugin and cannot be converted"),
+    ("wep_similar_name_2", False),
+    ("do_not_track", False),
+    ("prednat_policy", False),
+
+    # profile_long_labels Fails validation after conversion, but error is not clear.
+    # TODO: Add some error text once new validator lands and gives this test a sane error message
+    ("profile_long_labels", True),
+]
+random.shuffle(tests)
+
+
+@parameterized(tests)
+def test_converter(testname, fail_expected, error_text=None):
+    """
+    Convert a v1 object to v3, then apply the result and read it back.
+    """
+    test_converter.__name__ = testname
+    # Let's start every test afresh
+    wipe_etcd(get_ip())
+    testdata = data[testname]
+
+    # Convert data to V3 API using the tool under test
+    rc = calicoctl("convert", data=testdata)
+    if not fail_expected:
+        logger.debug("Trying to convert manifest from V1 to V3")
+        rc.assert_no_error()
+        # Get the converted yaml and clean it up (remove fields we don't care about)
+        converted_data = clean_calico_data(yaml.safe_load(rc.output))
+        original_resource = rc
+
+        # Apply the converted data
+        rc = calicoctl("create", data=original_resource.output)
+        logger.debug("Trying to create resource using converted manifest")
+        rc.assert_no_error()
+        rc = calicoctl("get %s %s -o yaml" % (converted_data['kind'], name(converted_data)))
+
+        # Comparison here needs to be against cleaned versions of data to remove Creation Timestamp
+        logger.debug("Comparing 'get'ted output with original converted yaml")
+        cleaned_output = yaml.safe_dump(
+            clean_calico_data(
+                yaml.safe_load(rc.output),
+                extra_keys_to_remove=['projectcalico.org/orchestrator', 'namespace']
+            )
+        )
+        original_resource.assert_data(cleaned_output)
+    else:
+        rc.assert_error(error_text)

--- a/tests/st/utils/v1_data.py
+++ b/tests/st/utils/v1_data.py
@@ -1,0 +1,477 @@
+# Copyright (c) 2017 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data = {}
+data['bgppeer_long_node_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'bgpPeer',
+    'metadata': {
+        'scope': 'node',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75',
+        'peerIP': '192.168.255.255',
+    },
+    'spec': {
+        'asNumber': "4294967294",
+    },
+}
+data['bgppeer_dotted_asn'] = {
+    'apiVersion': 'v1',
+    'kind': 'bgpPeer',
+    'metadata': {
+        'scope': 'global',
+        'peerIP': '2006::2:1',
+    },
+    'spec': {
+        'asNumber': "1.10",
+    },
+}
+data['hep_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {'type': 'production'},
+                 'name': 'eth0',
+                 'node': 'myhost'},
+    'spec': {'expectedIPs': ['192.168.0.1', '192.168.0.2'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_long_fields'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        '8roper.evil/02.key_name.which.is-also_very.long...1234567890.p': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0',
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_LongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_label_too_long'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        '8roper.evil/02.key_name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.Key_Name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.Key_name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.key_Name.which.is-also_very.long...1234567890..proper.evil-02.key_name.which.is-also_very.long...1234567890..proper.evil-02.9': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0',
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Her.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_bad_label'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        '8roper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/9': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0',
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Her.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_name_too_long'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {
+        'calico/k8s_ns': 'default',
+        'type': 'type-endFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75'},
+    'spec': {'expectedIPs': ['fd00:1::321'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['hep_mixed_ip'] = {
+    'apiVersion': 'v1',
+    'kind': 'hostEndpoint',
+    'metadata': {'labels': {'type': 'production'},
+                 'name': 'eth0',
+                 'node': 'myotherhost'},
+    'spec': {'expectedIPs': ['192.168.0.1',
+                             '192.168.0.2',
+                             'fd00:ca:fe:1d:52:bb:e9:80'],
+             'interfaceName': 'eth0',
+             'profiles': ['profile1', 'profile2']}
+}
+data['ippool_v4_small'] = {
+    'apiVersion': 'v1',
+    'kind': 'ipPool',
+    'metadata': {'cidr': '10.1.0.0/26'},
+    'spec': {'disabled': False,
+             'ipip': {'enabled': True, 'mode': 'cross-subnet'},
+             'nat-outgoing': True}
+}
+data['ippool_v4_large'] = {
+    'apiVersion': 'v1',
+    'kind': 'ipPool',
+    'metadata': {'cidr': '10.0.0.0/8'},
+    'spec': {'disabled': False,
+             'ipip': {'enabled': True, 'mode': 'always'},
+             'nat-outgoing': True}
+}
+data['ippool_mixed'] = {
+    'apiVersion': 'v1',
+    'kind': 'ipPool',
+    'metadata': {'cidr': '2006::/64'},
+    'spec': {'disabled': False,
+             'ipip': {'enabled': False, 'mode': 'always'},
+             'nat-outgoing': False}
+}
+data['node_long_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'node',
+    'metadata': {
+        'name': '-Mary_had-A-Little___Lamb--Whose---Fleece-Was-White.As.Snow...She-Also-Had_an-Evil-NodeName_in_order_to.break.upgrade-code201600'},
+    'spec': {'bgp': {'asNumber': '7.20',
+                     'ipv4Address': '10.244.0.1/24',
+                     'ipv6Address': '2001:db8:85a3::8a2e:370:7334/120'}}
+}
+data['node_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'node',
+    'metadata': {'name': 'node-hostname'},
+    'spec': {'bgp': {'asNumber': 64512,
+                     'ipv4Address': '10.244.0.1/24',
+                     'ipv6Address': '2001:db8:85a3::8a2e:370:7334/120'}}
+}
+data['policy_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'name': 'allow-tcp-6379'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [6379]},
+                          'protocol': 'tcp',
+                          'source': {'selector': "role == 'frontend'"}}],
+             'selector': "role == 'database'",
+             'types': ['ingress', 'egress']}
+}
+data['policy_long_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {
+        'name': '-Mary_had-A-Little___Lamb--Whose---Fleece-Was-White.As.Snow...She-Also-Had_an-Evil-PolicyName_in_order_to.break.upgrade-code2016'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [6379]},
+                          'protocol': 'tcp',
+                          'source': {'nets': ['192.168.0.1/32']}}],
+             'selector': "role == 'database'",
+             'types': ['ingress', 'egress']}
+}
+data['profile_tame'] = {
+    'apiVersion': 'v1',
+    'kind': 'profile',
+    'metadata': {'labels': {'profile': 'profile1'}, 'name': 'profile1'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'deny',
+                          'source': {'nets': ['10.0.20.0/24']}},
+                         {'action': 'allow',
+                          'source': {'selector': "profile == 'profile1'"}}]}
+}
+data['profile_long_labels'] = {
+    'apiVersion': 'v1',
+    'kind': 'profile',
+    'metadata': {'labels': {
+        '8roper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/Key_name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/key_Name.which/is-also_very.long...1234567890//proper/evil-02/key_name.which/is-also_very.long...1234567890//proper/evil-02/9': 'frontendFrontEnd.0123456789-_-23wdffrontendFrontEnd.0124679-_-0'},
+        'name': '-Mary_had-A-Little___Lamb--Whose---Fleece-Was-White.As.Snow...She-Also-Had_an-Evil-ProfileName_in_order_to.break.upgradeprofile1'},
+    'spec': {'egress': [{'action': 'allow'}],
+             'ingress': [{'action': 'deny',
+                          'source': {'nets': ['10.0.20.0/24',
+                                              '192.168.000.000/32',
+                                              '192.168.001.255/32',
+                                              '192.168.002.254/32',
+                                              '192.168.003.253/32',
+                                              '192.168.004.252/32',
+                                              '192.168.005.251/32',
+                                              '192.168.006.250/32',
+                                              '192.168.007.249/32',
+                                              '192.168.008.248/32',
+                                              '192.168.009.247/32',
+                                              '192.168.010.246/32',
+                                              '192.168.011.245/32',
+                                              '192.168.012.244/32',
+                                              '192.168.013.243/32',
+                                              '192.168.014.242/32',
+                                              '192.168.015.241/32',
+                                              '192.168.016.240/32',
+                                              '192.168.017.239/32',
+                                              '192.168.018.238/32',
+                                              '192.168.100.000/32',
+                                              '192.168.101.255/32',
+                                              '192.168.102.254/32',
+                                              '192.168.103.253/32',
+                                              '192.168.104.252/32',
+                                              '192.168.105.251/32',
+                                              '192.168.106.250/32',
+                                              '192.168.107.249/32',
+                                              '192.168.108.248/32',
+                                              '192.168.109.247/32',
+                                              '192.168.110.246/32',
+                                              '192.168.111.245/32',
+                                              '192.168.112.244/32',
+                                              '192.168.113.243/32',
+                                              '192.168.114.242/32',
+                                              '192.168.115.241/32',
+                                              '192.168.116.240/32',
+                                              '192.168.117.239/32',
+                                              '192.168.118.238/32',
+                                              '192.168.200.000/32',
+                                              '192.168.201.255/32',
+                                              '192.168.202.254/32',
+                                              '192.168.203.253/32',
+                                              '192.168.204.252/32',
+                                              '192.168.205.251/32',
+                                              '192.168.206.250/32',
+                                              '192.168.207.249/32',
+                                              '192.168.208.248/32',
+                                              '192.168.209.247/32',
+                                              '192.168.210.246/32',
+                                              '192.168.211.245/32',
+                                              '192.168.212.244/32',
+                                              '192.168.213.243/32',
+                                              '192.168.214.242/32',
+                                              '192.168.215.241/32',
+                                              '192.168.216.240/32',
+                                              '192.168.217.239/32',
+                                              '192.168.218.238/32',
+                                              '47.0.0.0/8']}},
+                         {'action': 'allow',
+                          'source': {'selector': "profile == 'profile1'"}}]}
+}
+data['policy_big'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'annotations': {'aname': 'avalue'}, 'name': 'allow-tcp-6379'},
+    'spec': {'egress': [{'action': 'allow',
+                         'icmp': {'code': 25, 'type': 25},
+                         'protocol': 'icmp'}],
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [6379]},
+                          'notProtocol': 'udplite',
+                          'protocol': 'tcp',
+                          'source': {
+                              'notSelector': "role != 'something' && thing in {'one', 'two'}",
+                              'selector': "role == 'frontend' && thing not in {'three', 'four'}"}},
+                         {'action': 'allow',
+                          'protocol': 'tcp',
+                          'source': {
+                              'notSelector': "role != 'something' && thing in {'one', 'two'}"}},
+                         {'action': 'deny',
+                          'destination': {'notPorts': [80],
+                                          'ports': [22, 443]},
+                          'protocol': 'tcp'},
+                         {'action': 'allow',
+                          'source': {'nets': ['172.18.18.200/32',
+                                              '172.18.19.0/24']}},
+                         {'action': 'allow',
+                          'source': {'net': '172.18.18.100/32'}},
+                         {'action': 'deny',
+                          'source': {'notNet': '172.19.19.100/32'}},
+                         {'action': 'deny',
+                          'source': {'notNets': ['172.18.0.0/16']}}],
+             'order': 1234,
+             'selector': "role == 'database' && !has(demo)",
+             'types': ['ingress', 'egress']}
+}
+data['profile_big'] = {
+    'apiVersion': 'v1',
+    'kind': 'profile',
+    'metadata': {'labels': {'profile': 'profile1'},
+                 'name': 'profile1',
+                 'tags': ['atag', 'btag']},
+    'spec': {'egress': [{'action': 'allow',
+                         'destination': {'notSelector': "profile == 'system'"}},
+                        {'action': 'allow',
+                         'source': {'selector': "something in {'a', 'b'}"}},
+                        {'action': 'allow',
+                         'destination': {'selector': "something not in {'a', 'b'}"}}],
+             'ingress': [{'action': 'deny',
+                          'destination': {'notPorts': [22, 443, 21, 8080],
+                                          'tag': 'atag'},
+                          'protocol': 'udp',
+                          'source': {'net': '172.20.0.0/16',
+                                     'notNet': '172.20.5.0/24',
+                                     'notTag': 'dtag',
+                                     'tag': 'ctag'}},
+                         {'action': 'deny',
+                          'destination': {'notPorts': [22, 443, 21, 8080],
+                                          'tag': 'atag'},
+                          'protocol': 'tcp',
+                          'source': {'nets': ['10.0.21.128/25'],
+                                     'notNets': ['10.0.20.0/24']}},
+                         {'action': 'deny',
+                          'protocol': 'tcp',
+                          'source': {'notNets': ['10.0.21.128/25']}},
+                         {'action': 'allow',
+                          'protocol': 'tcp',
+                          'source': {'ports': [1234, 4567, 489],
+                                     'selector': "profile != 'profile1' && has(role)"}}]}
+}
+data['wep_lots_ips'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {'app': 'frontend', 'calico/k8s_ns': 'default'},
+                 'name': 'eth0',
+                 'node': 'rack1-host1',
+                 'orchestrator': 'k8s',
+                 'workload': 'default.frontend-5gs43'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['192.168.000.000/32',
+                            '192.168.001.255/32',
+                            '192.168.002.254/32',
+                            '192.168.003.253/32',
+                            '192.168.004.252/32',
+                            '192.168.005.251/32',
+                            '192.168.006.250/32',
+                            '192.168.007.249/32',
+                            '192.168.008.248/32',
+                            '192.168.009.247/32',
+                            '192.168.010.246/32',
+                            '192.168.011.245/32',
+                            '192.168.012.244/32',
+                            '192.168.013.243/32',
+                            '192.168.014.242/32',
+                            '192.168.015.241/32',
+                            '192.168.016.240/32',
+                            '192.168.017.239/32',
+                            '192.168.018.238/32',
+                            '192.168.100.000/32',
+                            '192.168.101.255/32',
+                            '192.168.102.254/32',
+                            '192.168.103.253/32',
+                            '192.168.104.252/32',
+                            '192.168.105.251/32',
+                            '192.168.106.250/32',
+                            '192.168.107.249/32',
+                            '192.168.108.248/32',
+                            '192.168.109.247/32',
+                            '192.168.110.246/32',
+                            '192.168.111.245/32',
+                            '192.168.112.244/32',
+                            '192.168.113.243/32',
+                            '192.168.114.242/32',
+                            '192.168.115.241/32',
+                            '192.168.116.240/32',
+                            '192.168.117.239/32',
+                            '192.168.118.238/32',
+                            '192.168.200.000/32',
+                            '192.168.201.255/32',
+                            '192.168.202.254/32',
+                            '192.168.203.253/32',
+                            '192.168.204.252/32',
+                            '192.168.205.251/32',
+                            '192.168.206.250/32',
+                            '192.168.207.249/32',
+                            '192.168.208.248/32',
+                            '192.168.209.247/32',
+                            '192.168.210.246/32',
+                            '192.168.211.245/32',
+                            '192.168.212.244/32',
+                            '192.168.213.243/32',
+                            '192.168.214.242/32',
+                            '192.168.215.241/32',
+                            '192.168.216.240/32',
+                            '192.168.217.239/32',
+                            '192.168.218.238/32'],
+             'mac': 'ca:fe:1d:52:bb:e9',
+             'profiles': ['profile1']}
+}
+data['wep_similar_name'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {'app': 'frontend', 'calico/k8s_ns': 'default'},
+                 'name': 'eth0',
+                 'node': 'rack1-host1',
+                 'orchestrator': 'k8s',
+                 'workload': 'default/frontend-5gs43'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['192.168.0.0/32',
+                            '192.168.1.255/32',
+                            '192.168.2.254/32',
+                            '192.168.3.253/32',
+                            '192.168.4.252/32',
+                            '192.168.5.251/32',
+                            '192.168.6.250/32',
+                            '192.168.7.249/32',
+                            '192.168.8.248/32',
+                            '192.168.9.247/32',
+                            '192.168.10.246/32',
+                            '192.168.11.245/32',
+                            '192.168.12.244/32',
+                            '192.168.13.243/32',
+                            '192.168.14.242/32',
+                            '192.168.15.241/32',
+                            '192.168.16.240/32',
+                            '192.168.17.239/32',
+                            '192.168.18.238/32'],
+             'mac': 'fe:ed:ca:fe:00:00',
+             'profiles': ['profile1']}
+}
+data['wep_bad_workload_id'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {
+        'calico/k8s_ns': 'default'},
+        'name': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_AlsoAVeryLongInterfaceNameTryingToCatchOutUpgradeCode75',
+        'node': '.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My.Spout.Im_Also.A.Very.LongNodeNameTryingTo-CatchOut_UpgradeCode75',
+        'orchestrator': 'k8s',
+        'workload': 'default.-_.123Im_a_Little.Teapot-Short_And-Stout.Heres-My-Handle_Heres_My_AlsoAVeryLongWorkload-NameTryingToCatchOutUpgradeCode5'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['192.168.255.255/32', 'fd::1:40'],
+             'mac': 'ca:fe:1d:52:bb:e9',
+             'profiles': ['profile1']}
+}
+data['wep_similar_name_2'] = {
+    'apiVersion': 'v1',
+    'kind': 'workloadEndpoint',
+    'metadata': {'labels': {'app': 'frontend', 'calico/k8s_ns': 'default'},
+                 'name': 'eth0',
+                 'node': 'rack1-host1',
+                 'orchestrator': 'k8s',
+                 'workload': 'default.frontend.5gs43'},
+    'spec': {'interfaceName': 'cali0ef24ba',
+             'ipNetworks': ['fd00:ca:fe:1d:52:bb:e9:80'],
+             'mac': 'ca:fe:1d:52:bb:e9',
+             'profiles': ['profile1']}
+}
+data['do_not_track'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'name': 'allow-tcp-555-donottrack'},
+    'spec': {'doNotTrack': True,
+             'ingress': [{'action': 'allow',
+                          'destination': {'ports': [555]},
+                          'protocol': 'tcp',
+                          'source': {'selector': "role == 'cache'"}}],
+             'order': 1230,
+             'selector': "role == 'database'",
+             'types': ['ingress']}
+}
+data['prednat_policy'] = {
+    'apiVersion': 'v1',
+    'kind': 'policy',
+    'metadata': {'name': 'allow-cluster-internal-ingress'},
+    'spec': {'ingress': [{'action': 'allow',
+                          'source': {'nets': ['10.240.0.0/16',
+                                              '192.168.0.0/16']}}],
+             'order': 10,
+             'preDNAT': True,
+             'selector': 'has(host-endpoint)'}
+}


### PR DESCRIPTION
Adds FV tests for the converter: `calicoctl convert`.

## Validation:
```
$ make st

<snipped out test run output>

----------------------------------------------------------------------
XML: /code/nosetests.xml
[success] 3.45% tests.st.calicoctl.test_upgrade.hep_tame('hep_tame', False): 2.6423s
[success] 3.44% tests.st.calicoctl.test_upgrade.policy_big('policy_big', False): 2.6295s
[success] 3.43% tests.st.calicoctl.test_upgrade.bgppeer_dotted_asn('bgppeer_dotted_asn', False): 2.6202s
[success] 3.21% tests.st.calicoctl.test_upgrade.node_long_name('node_long_name', False): 2.4550s
[success] 3.21% tests.st.calicoctl.test_upgrade.bgppeer_long_node_name('bgppeer_long_node_name', False): 2.4543s
[success] 3.13% tests.st.calicoctl.test_upgrade.profile_big('profile_big', False): 2.3951s
[success] 3.13% tests.st.calicoctl.test_upgrade.policy_tame('policy_tame', False): 2.3910s
[success] 3.07% tests.st.calicoctl.test_upgrade.hep_long_fields('hep_long_fields', False): 2.3474s
[success] 3.03% tests.st.calicoctl.test_upgrade.wep_lots_ips('wep_lots_ips', False): 2.3173s
[success] 3.02% tests.st.calicoctl.test_upgrade.profile_long_labels('profile_long_labels', True): 2.3064s
[success] 3.01% tests.st.calicoctl.test_upgrade.ippool_v4_large('ippool_v4_large', False): 2.3007s
[success] 2.97% tests.st.calicoctl.test_upgrade.prednat_policy('prednat_policy', False): 2.2750s
[success] 2.97% tests.st.calicoctl.test_upgrade.wep_similar_name('wep_similar_name', True, 'workload was not added through the Calico CNI plugin and cannot be converted'): 2.2687s
[success] 2.96% tests.st.calicoctl.test_upgrade.wep_similar_name_2('wep_similar_name_2', False): 2.2651s
[success] 2.96% tests.st.calicoctl.test_upgrade.do_not_track('do_not_track', False): 2.2619s
[success] 2.91% tests.st.calicoctl.test_upgrade.ippool_v4_small('ippool_v4_small', False): 2.2287s
[success] 2.85% tests.st.calicoctl.test_upgrade.ippool_mixed('ippool_mixed', False): 2.1835s
[success] 2.80% tests.st.calicoctl.test_upgrade.profile_tame('profile_tame', False): 2.1400s
[success] 2.77% tests.st.calicoctl.test_upgrade.hep_label_too_long('hep_label_too_long', True, 'name part must be no more than 63 characters'): 2.1156s
[success] 2.76% tests.st.calicoctl.test_upgrade.node_tame('node_tame', False): 2.1085s
[success] 2.75% tests.st.calicoctl.test_upgrade.hep_mixed_ip('hep_mixed_ip', False): 2.1050s
[success] 2.75% tests.st.calicoctl.test_upgrade.hep_bad_label('hep_bad_label', True, 'a qualified name must consist of alphanumeric characters'): 2.1013s
[success] 2.73% tests.st.calicoctl.test_upgrade.policy_long_name('policy_long_name', False): 2.0917s
[success] 2.61% tests.st.calicoctl.test_upgrade.wep_bad_workload_id('wep_bad_workload_id', True, "field must not begin with a '-'"): 1.9999s
[success] 2.60% tests.st.calicoctl.test_upgrade.hep_name_too_long('hep_name_too_long', True, 'name is too long by 11 bytes'): 1.9849s
[success] 2.20% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_get: 1.6838s
[success] 1.50% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_namespaced_0: 1.1479s
[success] 1.31% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_namespaced_1: 1.0010s
[success] 1.08% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_0: 0.8271s
[success] 0.84% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_bgpconfig: 0.6435s
[success] 0.84% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_json: 0.6393s
[success] 0.83% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_clusterinfo: 0.6347s
[success] 0.74% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_replace_with_resource_version: 0.5691s
[success] 0.71% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_apply_with_resource_version: 0.5440s
[success] 0.70% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_file_multi: 0.5391s
[success] 0.68% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_stdin: 0.5235s
[success] 0.68% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_export_flag: 0.5174s
[success] 0.67% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_felixconfig: 0.5103s
[success] 0.65% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_metadata_unchanged_0_create: 0.4976s
[success] 0.55% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_delete_with_resource_version: 0.4235s
[success] 0.55% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_metadata_unchanged_1_apply: 0.4218s
[success] 0.54% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_file_single_list: 0.4165s
[success] 0.52% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_disallow_crud_on_knp_defaults: 0.3988s
[success] 0.45% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_5: 0.3470s
[success] 0.44% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_2: 0.3349s
[success] 0.41% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_1: 0.3132s
[success] 0.39% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_3: 0.3018s
[success] 0.39% tests.st.calicoctl.test_crud.TestCalicoctlCommands.test_non_namespaced_4: 0.2998s
[success] 0.38% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_18_pool_invalidNet6: 0.2871s
[success] 0.37% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_0_bgpPeer_invalidASnum: 0.2825s
[success] 0.35% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_3_bgpPeer_invalidIpv6: 0.2667s
[success] 0.35% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_2_bgpPeer_apiversion: 0.2643s
[success] 0.33% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_19_pool_invalidNet7: 0.2495s
[success] 0.33% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_16_pool_invalidNet3: 0.2493s
[success] 0.33% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_10_policy_invalidLowPortinList: 0.2490s
[success] 0.32% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_4_bgpPeer_invalidnodename: 0.2467s
[success] 0.32% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_14_pool_invalidNet1: 0.2458s
[success] 0.32% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_25_compound_config: 0.2454s
[success] 0.31% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_20_pool_invalidNet8: 0.2407s
[success] 0.31% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_13_policy_NetworkPolicyNameRejected: 0.2401s
[success] 0.31% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_5_bgpPeer_unrecognisedfield: 0.2379s
[success] 0.30% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_21_pool_invalidIpIp1: 0.2314s
[success] 0.29% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_15_pool_invalidNet2: 0.2255s
[success] 0.29% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_1_bgpPeer_invalidIP: 0.2202s
[success] 0.29% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_12_policy_invalidAction: 0.2198s
[success] 0.28% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_17_pool_invalidNet4: 0.2159s
[success] 0.26% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_6_hostEndpoint_invalidInterface: 0.2009s
[success] 0.26% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_22_pool_invalidIpIp2: 0.2002s
[success] 0.25% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_9_policy_invalidLowPortinRange: 0.1937s
[success] 0.25% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_11_policy_invalidReversedRange: 0.1918s
[success] 0.25% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_7_policy_invalidHighPortinList: 0.1906s
[success] 0.25% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_24_profile_ICMPcode: 0.1876s
[success] 0.25% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_8_policy_invalidHighPortinRange: 0.1875s
[success] 0.24% tests.st.calicoctl.test_crud.InvalidData.test_invalid_profiles_rejected_23_profile_ICMPtype: 0.1864s
----------------------------------------------------------------------
Ran 74 tests in 76.501s

OK
make stop-etcd

```