### PR TITLE
Disallow any updates on old resource versions to fix etcd compaction errors

### DIFF
--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -736,6 +736,38 @@ class TestCalicoctlCommands(TestBase):
         rc = calicoctl("delete", data=k8s_np)
         rc.assert_error(text=NOT_SUPPORTED)
         rc.assert_error(text=KUBERNETES_NP)
+
+    @parameterized.expand([
+        ('replace'),
+        ('apply'),
+    ])
+    def test_disallow_update_old_resource_version(self, update_cmd):
+        """
+        Test that we disallow updates on resources with old resource versions.
+        """
+        rc = calicoctl("create", data=ippool_name1_rev1_v4)
+        rc.assert_no_error()
+
+        rc = calicoctl(
+                "get ippool %s -o yaml" % name(ippool_name1_rev1_v4))
+        rc.assert_no_error()
+        rev1 = rc.decoded
+
+        rc = calicoctl(update_cmd, data=rev1)
+        rc.assert_no_error()
+
+        rc = calicoctl(
+                "get ippool %s -o yaml" % name(ippool_name1_rev1_v4))
+        rc.assert_no_error()
+        rev2 = rc.decoded
+        self.assertNotEqual(rev1['metadata']['resourceVersion'], rev2['metadata']['resourceVersion'])
+
+        rc = calicoctl(update_cmd, data=rev1)
+        rc.assert_error(text=ERROR_CONFLICT)
+
+        # Delete the resource
+        rc = calicoctl("delete ippool %s" % name(ippool_name1_rev1_v4))
+        rc.assert_no_error()
 #
 #
 # class TestCreateFromFile(TestBase):


### PR DESCRIPTION
In cases where a resource version has been compacted in etcd and is then attempted to be updated, it gives the unclear error message `resource: etcdserver: mvcc: required revision has been compacted` instead of notifying the user that they are passing in an old resource version. This fixes the error message and makes it so updates are always done against the newest version of the resource.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
