### PR TITLE
disable --version flag (prefer the 'version' command)

### DIFF
--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -53,7 +53,7 @@ Description:
 
   See 'calicoctl <command> --help' to read about a specific subcommand.
 `
-	arguments, _ := docopt.Parse(doc, nil, true, commands.VERSION_SUMMARY, true, false)
+	arguments, _ := docopt.Parse(doc, nil, true, "", true, false)
 
 	if logLevel := arguments["--log-level"]; logLevel != nil {
 		parsedLogLevel, err := log.ParseLevel(logLevel.(string))


### PR DESCRIPTION
## Description
`docopts` provides an implicit `--version` flag even when you don't pass in a command.

However the output is terse and doesn't agree with the output from the `version` command. For example:
* `--version`: `calicoctl version v2.0.0-10-gec291442-dirty, build ec291442, CNX`
* `version` command:
```
    Client Version:    v2.0.0-10-gec291442-dirty
    Release:           CNX
    Build date:        2018-02-22T23:33:12+0000
    Git commit:        ec291442
    Cluster Calico Version:  v3.0.1
    Cluster CNX Version:     unknown
    Cluster Type:            kubeadm,bgp,k8s
```
This PR disables the `--version` flag - just like kubectl, e.g.:
```
# kubectl --version
error: unknown flag: --version
```

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
