### PR TITLE
Update libcalico-go to 0eaf5e19571c17f485112faf870688cd6da4a057

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6eef23170517627d0869a1841d0ca342572d0d0eb5554a216822e6fb041d1133
-updated: 2018-03-12T15:55:35.757382055Z
+hash: 546649e798e65352bb1d4034dace0678bc5d8fdb3039d87e228d07f47edae981
+updated: 2018-03-23T16:27:43.590361765Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -16,7 +16,7 @@ imports:
   - autorest/azure
   - autorest/date
 - name: github.com/beorn7/perks
-  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/coreos/etcd
@@ -105,7 +105,7 @@ imports:
   subpackages:
   - simplelru
 - name: github.com/hashicorp/hcl
-  version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
+  version: f40e974e75af4e271d97ce0fc917af5898ae7bda
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -121,7 +121,7 @@ imports:
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/influxdata/influxdb
-  version: 335aa4cdb7e7919c119f6f1bc4bd29b0bdacd04b
+  version: e7e0cf0322c45718d65ea6cdcb2624453bb7fcc6
   subpackages:
   - client/v2
   - models
@@ -143,7 +143,7 @@ imports:
 - name: github.com/mattn/go-runewidth
   version: a9d6d1e4dc51df2130326793d49971f238839169
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/mcuadros/go-version
@@ -217,7 +217,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 49c0d0164441316a4bc430da232a8a6d7703275d
+  version: 0eaf5e19571c17f485112faf870688cd6da4a057
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -281,7 +281,7 @@ imports:
 - name: github.com/sirupsen/logrus
   version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/spf13/afero
-  version: bbf41cb36dffe15dff5bf7e18c447801e7ffe163
+  version: a880a37ed1804d98f64b3b7d58b5e3f8fbf421c4
   subpackages:
   - mem
 - name: github.com/spf13/cast
@@ -291,11 +291,11 @@ imports:
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/spf13/viper
-  version: aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5
+  version: b5e8006cbee93ec955a89ab31e0e3ce3204f3736
 - name: github.com/termie/go-shutil
   version: bcacb06fecaeec8dc42af03c87c6949f4a05c74c
 - name: github.com/vishvananda/netlink
-  version: 5236321576c0c97ab02c078e60f9b1c5c1828807
+  version: 41009d533ba0788a139b0b6ef38923a23b3766d3
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
@@ -400,7 +400,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 389dfa299845bcf399c16af89987e8775718ea48
+  version: 3c2a58f9923aeb5d27fa4d91249e45a1460ca3bd
   subpackages:
   - admissionregistration/v1alpha1
   - apps/v1beta1
@@ -427,7 +427,7 @@ imports:
   - storage/v1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 4972c8e335e32ab65ba45bde0a99c6544c8a8e4c
+  version: ab7fc865fb0881d161f37adef3e5a67b89a18d05
   subpackages:
   - pkg/api/equality
   - pkg/api/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -33,7 +33,7 @@ import:
 - package: github.com/sirupsen/logrus
   version: v1.0.4
 - package: github.com/projectcalico/libcalico-go
-  version: 49c0d0164441316a4bc430da232a8a6d7703275d
+  version: 0eaf5e19571c17f485112faf870688cd6da4a057
   subpackages:
   - lib/apis/v3
   - lib/clientv3


### PR DESCRIPTION
## Description
Update libcalico-go https://github.com/projectcalico/libcalico-go/pull/829