### PR TITLE
Handle unsupported applies

### DIFF
--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -602,7 +602,7 @@ class TestCalicoctlCommands(TestBase):
         # Apply an update to the cluster information and assert not found (we need the node to
         # create it).
         rc = calicoctl("apply", data=clusterinfo_name1_rev2)
-        rc.assert_error(NOT_FOUND)
+        rc.assert_error(NOT_SUPPORTED)
 
         # Delete the resource by name (i.e. without using a resource version) - assert not
         # supported.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

~This PR fixes the issue where running an Apply against a resource where Create is not supported returns a "not found error". We now will return "operation not supported".~

~Implemented by changing error logic for `Apply` such that if the `Create` is Unsupported and `Update` is NotFound, return the Create's Unsupported error.~

~I needed to revert my original fix for this (#1831 ) since there are resources that you can Apply but not Create: Node resources in KDD mode.~

Added a special case for the "clusterinfo apply" so that we return `unsupported` error. This fixes an issue where running `apply` against a clusterinfo with name != default returns a `not found` error (since the `create` is unsupported and the `update` needs to run a `get` first).

I'm not happy about adding clusterinfo specific code to the abstract resourcemgr class but I also don't want to refactor this system until we are certain there is more than this scenario.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
