### PR TITLE
Create default arch-less image when building on amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,9 @@ image: calico/ctl
 calico/ctl: $(CTL_CONTAINER_CREATED)
 $(CTL_CONTAINER_CREATED): Dockerfile.$(ARCH) dist/calicoctl
 	docker build -t $(CTL_CONTAINER_NAME):latest-$(ARCH) -f Dockerfile.$(ARCH) .
+ifeq ($(ARCH),amd64)
+	docker tag $(CTL_CONTAINER_NAME):latest-$(ARCH) $(CTL_CONTAINER_NAME):latest
+endif
 	touch $@
 
 ## Build calicoctl on local system with installed go


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Previous PR #1838 created images with the structure `calico/ctl:latest-$(ARCH)` and `calico/ctl:$(VERSION)-$(ARCH)`. To keep existing structures working, `make release` tags `calico/ctl:latest-amd64` with `calico/ctl:latest` (and the same for `$(VERSION)`). However, semaphore requires the arch-less `calico/ctl:latest` _prior_ to running `make release`.

This PR adds the `docker tag calico/ctl:latest-amd64 calico/ctl:latest` to `make calico/ctl`, which solves the semaphore issue.

This also is in line with:

* how we do `make build` - add arch-less binary when on `amd64`
* how we do images (and binary) on felix, etc.

cc @fasaxc 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```