### PR TITLE
Fix dist/calicoctl for building on host arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,8 @@ binary: $(CALICOCTL_FILES) vendor
 
 
 dist/calicoctl: $(CALICOCTL_FILES) vendor
-	$(MAKE) dist/calicoctl-linux-amd64
-	cp dist/calicoctl-linux-amd64 dist/calicoctl
+	$(MAKE) dist/calicoctl-linux-$(ARCH)
+	cp dist/calicoctl-linux-$(ARCH) dist/calicoctl
 
 ## build for linux on amd64
 dist/calicoctl-linux-amd64: $(CALICOCTL_FILES) vendor


### PR DESCRIPTION
This PR is for fixing dist/calicoctl target for building this project on host architecture. Previously is was building only `adm64` even we run this target on any machines like `ppc64le,arm64 etc...`