### PR TITLE
fix up docker filter for name=calico

### DIFF
--- a/calicoctl/commands/node/diags.go
+++ b/calicoctl/commands/node/diags.go
@@ -165,7 +165,7 @@ func getNodeContainerLogs(logDir string) {
 	os.Mkdir(logDir, os.ModeDir)
 
 	// Get a list of Calico containers running on this Node.
-	result, err := exec.Command("docker", "ps", "-a", "--filter", "\"name=calico\"", "--format", "{{.Names}}: {{.CreatedAt}}").CombinedOutput()
+	result, err := exec.Command("docker", "ps", "-a", "--filter", "name=calico", "--format", "{{.Names}}: {{.CreatedAt}}").CombinedOutput()
 	if err != nil {
 		fmt.Printf("Could not run docker command: %s\n", string(result))
 		return


### PR DESCRIPTION
## Description
`exec.Command()` doesn't correctly handle escaped quotes. Consequently the `docker ps -a --filter "name=calico"` command fails and we're not correctly listing relevant pods to examine for the diag. The fix is to remove the escaped quotes from the invocation.

See https://stackoverflow.com/questions/26473674/double-quotes-escaping-in-golang-exec

Addresses issue: https://github.com/projectcalico/calicoctl/issues/1852

cherry-pick: https://github.com/projectcalico/calicoctl/pull/1853/commits/29bcb35b77062ea3c532f848e3eaf7a30d3b3c8d

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix invalid filter in "calicoctl node diags" command
```

