### PR TITLE
descriptive error for profile apply failure on kdd

### DIFF
--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -172,10 +172,9 @@ func (rh resourceHelper) Apply(ctx context.Context, client client.Interface, res
 	// Try to create the resource first.
 	ro, err := rh.Create(ctx, client, resource)
 
-	// Fall back to an Update if the resource already exists, or the datastore does not support
-	// create operations for that resource.
+	// Fall back to an Update if the resource already exists.
 	switch err.(type) {
-	case cerrors.ErrorResourceAlreadyExists, cerrors.ErrorOperationNotSupported:
+	case cerrors.ErrorResourceAlreadyExists:
 		// Insert the original ResourceVersion back into the object before trying the Update.
 		resource.(ResourceObject).GetObjectMeta().SetResourceVersion(originalRV)
 

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -759,7 +759,7 @@ class TestCalicoctlCommands(TestBase):
         rc.assert_error(text=KUBERNETES_NP)
 
         rc = calicoctl("apply", data=k8s_np)
-        rc.assert_error(text=NOT_FOUND)
+        rc.assert_error(text=NOT_SUPPORTED)
 
         rc = calicoctl("replace", data=k8s_np)
         rc.assert_error(text=NOT_FOUND)


### PR DESCRIPTION
## Description

Add a descriptive error for attempting to apply a `profile` with kdd. Error message used to be:

```bash
Failed to apply 'Profile' resource: Revision  invalid
```

This PR makes it more clear:
```bash
Failed to apply 'Profile' resource: operation Create is not supported on Profile(profile1) 
```

fixes https://github.com/projectcalico/calicoctl/issues/1827

## Todos
- [x] Tests

## Release Note

```release-note
None required
```
Signed-off-by: derek mcquay <derek@tigera.io>