### PR TITLE
Replace docopt with spf13/cobra

### DIFF
--- a/calicoctl/commands/args.go
+++ b/calicoctl/commands/args.go
@@ -1,0 +1,151 @@
+package commands
+
+import (
+	flag "github.com/spf13/pflag"
+
+	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+)
+
+// mapable defines the interface to maintain backward compatability with the docopt implementation
+type mapable interface {
+	mapArgs() map[string]interface{}
+}
+
+// baseResourceArgs defines the base set of args for a resource-based command
+// (apply, create, delete, get, replace)
+type baseResourceArgs struct {
+	filename, config, namespace *string
+}
+
+// newBaseResourceArgs parses a flagset to generate a baseResourceArgs instance
+func newBaseResourceArgs(fs *flag.FlagSet) baseResourceArgs {
+	return baseResourceArgs{
+		filename: fs.StringP(
+			"filename", "f", "",
+			"Filename to use to apply the resource"),
+		config: fs.StringP(
+			"config", "c", constants.DefaultConfigPath,
+			"Path to the file containing connection configuration in YAML or JSON format."),
+		namespace: fs.StringP(
+			"namespace", "n", "",
+			"Filename to use to apply the resource"),
+	}
+}
+
+// mapArgs converts the baseResourceArgs to map[string]interface{}
+func (args baseResourceArgs) mapArgs() map[string]interface{} {
+	return map[string]interface{}{
+		"--filename":  *args.filename,
+		"--config":    *args.config,
+		"--namespace": *args.namespace,
+	}
+}
+
+// getResourceArgs defines the extended set of args for a "get" command
+type getResourceArgs struct {
+	baseResourceArgs
+	allNamespaces, export *bool
+	output                *string
+}
+
+// newGetResourceArgs parses a flagset to generate a getResourceArgs instance
+func newGetResourceArgs(fs *flag.FlagSet) getResourceArgs {
+	return getResourceArgs{
+		baseResourceArgs: newBaseResourceArgs(fs),
+		allNamespaces: fs.BoolP(
+			"all-namespaces", "a", false,
+			"If present, list the requested object(s) access all nammespaces"),
+		export: fs.BoolP(
+			"export", "e", false,
+			`If present, returns the requested object(s) stripped of cluster-specific information. 
+This flag will be ignored if <NAME> is not specified`),
+		output: fs.StringP(
+			"output", "o", "ps",
+			`Output format. One of: yaml, json, ps, wide, 
+custom-columns=..., go-template=..., go-template-file=... [Default: ps]`),
+	}
+}
+
+// mapArgs converts the getResourceArgs to map[string]interface{}
+func (args getResourceArgs) mapArgs() map[string]interface{} {
+	m := args.baseResourceArgs.mapArgs()
+	m["--all-namespaces"] = *args.allNamespaces
+	m["--export"] = *args.export
+	m["--output"] = *args.output
+	return m
+}
+
+// createResourceArgs defines the extended set of args for a "create" command
+type createResourceArgs struct {
+	baseResourceArgs
+	skipExists *bool
+}
+
+// newCreateResourceArgs parses a flagset to generate a createResourceArgs instance
+func newCreateResourceArgs(fs *flag.FlagSet) createResourceArgs {
+	return createResourceArgs{
+		baseResourceArgs: newBaseResourceArgs(fs),
+		skipExists: fs.Bool(
+			"skip-exists", false,
+			"Skip over and treat as successful any attempts to create an entry that already exists"),
+	}
+}
+
+// mapArgs converts the createResourceArgs to map[string]interface{}
+func (args createResourceArgs) mapArgs() map[string]interface{} {
+	m := args.baseResourceArgs.mapArgs()
+	m["--skip-exists"] = *args.skipExists
+	return m
+}
+
+// deleteResourceArgs defines the extended set of args for a "delete" command
+type deleteResourceArgs struct {
+	baseResourceArgs
+	skipNotExists *bool
+}
+
+// newDeleteResourceArgs parses a flagset to generate a deleteResourceArgs instance
+func newDeleteResourceArgs(fs *flag.FlagSet) deleteResourceArgs {
+	return deleteResourceArgs{
+		baseResourceArgs: newBaseResourceArgs(fs),
+		skipNotExists: fs.Bool(
+			"skip-not-exists", false,
+			"Skip over and treat as successful, resources that don't exist."),
+	}
+}
+
+// mapArgs converts the deleteResourceArgs to map[string]interface{}
+func (args deleteResourceArgs) mapArgs() map[string]interface{} {
+	m := args.baseResourceArgs.mapArgs()
+	m["--skip-not-exists"] = *args.skipNotExists
+	return m
+}
+
+// convertArgs defines the set of args for a "convert" command
+type convertArgs struct {
+	filename, output *string
+	ignoreValidation *bool
+}
+
+// newConvertArgs parses a flagset to generate a deleteResourceArgs instance
+func newConvertArgs(fs *flag.FlagSet) convertArgs {
+	return convertArgs{
+		filename: fs.StringP(
+			"filename", "f", "",
+			`Filename to use to create the resource. If set to "-" loads from stdin.`),
+		output: fs.StringP(
+			"output", "o", "yaml",
+			"Output format. One of: yaml or json."),
+		ignoreValidation: fs.Bool(
+			"ignore-validation", false, "Skip validation on the converted manifest."),
+	}
+}
+
+// mapArgs converts the convertArgs to map[string]interface{}
+func (args convertArgs) mapArgs() map[string]interface{} {
+	return map[string]interface{}{
+		"--filename":          *args.filename,
+		"--output":            *args.output,
+		"--ignore-validation": *args.ignoreValidation,
+	}
+}

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -17,45 +17,30 @@ package commands
 import (
 	"fmt"
 	"os"
-	"strings"
 
-	"github.com/docopt/docopt-go"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/spf13/cobra"
 )
 
-func Delete(args []string) {
-	doc := constants.DatastoreIntro + `Usage:
-  calicoctl delete ( (<KIND> [<NAME>]) |
-                   --filename=<FILE>)
-                   [--skip-not-exists] [--config=<CONFIG>] [--namespace=<NS>]
+func init() {
+	deleteCommandArgs = newDeleteResourceArgs(DeleteCommand.Flags())
+	DeleteCommand.MarkFlagRequired("filename")
+}
 
-Examples:
-  # Delete a policy using the type and name specified in policy.yaml.
+var (
+	deleteCommandArgs deleteResourceArgs
+	DeleteCommand     = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a Calico resource.",
+		Example: `# Delete a policy using the type and name specified in policy.yaml.
   calicoctl delete -f ./policy.yaml
 
   # Delete a policy based on the type and name in the YAML passed into stdin.
   cat policy.yaml | calicoctl delete -f -
 
   # Delete policy with name "foo"
-  calicoctl delete policy foo
-
-Options:
-  -h --help                 Show this screen.
-  -s --skip-not-exists      Skip over and treat as successful, resources that
-                            don't exist.
-  -f --filename=<FILENAME>  Filename to use to delete the resource.  If set to
-                            "-" loads from stdin.
-  -c --config=<CONFIG>      Path to the file containing connection
-                            configuration in YAML or JSON format.
-                            [default: ` + constants.DefaultConfigPath + `]
-  -n --namespace=<NS>       Namespace of the resource.
-                            Only applicable to NetworkPolicy and WorkloadEndpoint.
-                            Uses the default namespace if not specified.
-
-Description:
-  The delete command is used to delete a set of resources by filename or stdin,
+  calicoctl delete policy foo`,
+		Long: `The delete command is used to delete a set of resources by filename or stdin,
   or by type and identifiers.  JSON and YAML formats are accepted for file and
   stdin format.
 
@@ -89,50 +74,43 @@ Description:
 
   The resources are deleted in the order they are specified.  In the event of a
   failure deleting a specific resource it is possible to work out which
-  resource failed based on the number of resources successfully deleted.
-`
-	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
-	if err != nil {
-		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
-		os.Exit(1)
-	}
-	if len(parsedArgs) == 0 {
-		return
-	}
+  resource failed based on the number of resources successfully deleted.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			results := executeConfigCommand(deleteCommandArgs.mapArgs(), actionDelete)
+			log.Infof("results: %+v", results)
 
-	results := executeConfigCommand(parsedArgs, actionDelete)
-	log.Infof("results: %+v", results)
-
-	if results.fileInvalid {
-		fmt.Printf("Failed to execute command: %v\n", results.err)
-		os.Exit(1)
-	} else if results.numHandled == 0 {
-		if results.numResources == 0 {
-			fmt.Printf("No resources specified in file\n")
-		} else if results.numResources == 1 {
-			fmt.Printf("Failed to delete '%s' resource: %v\n", results.singleKind, results.err)
-		} else if results.singleKind != "" {
-			fmt.Printf("Failed to delete any '%s' resources: %v\n", results.singleKind, results.err)
-		} else {
-			fmt.Printf("Failed to delete any resources: %v\n", results.err)
-		}
-		os.Exit(1)
-	} else if results.err == nil {
-		if results.singleKind != "" {
-			fmt.Printf("Successfully deleted %d '%s' resource(s)\n", results.numHandled, results.singleKind)
-		} else {
-			fmt.Printf("Successfully deleted %d resource(s)\n", results.numHandled)
-		}
-	} else {
-		fmt.Printf("Partial success: ")
-		if results.singleKind != "" {
-			fmt.Printf("deleted the first %d out of %d '%s' resources:\n",
-				results.numHandled, results.numResources, results.singleKind)
-		} else {
-			fmt.Printf("deleted the first %d out of %d resources:\n",
-				results.numHandled, results.numResources)
-		}
-		fmt.Printf("Hit error: %v\n", results.err)
-		os.Exit(1)
+			if results.fileInvalid {
+				fmt.Printf("Failed to execute command: %v\n", results.err)
+				os.Exit(1)
+			} else if results.numHandled == 0 {
+				if results.numResources == 0 {
+					fmt.Printf("No resources specified in file\n")
+				} else if results.numResources == 1 {
+					fmt.Printf("Failed to delete '%s' resource: %v\n", results.singleKind, results.err)
+				} else if results.singleKind != "" {
+					fmt.Printf("Failed to delete any '%s' resources: %v\n", results.singleKind, results.err)
+				} else {
+					fmt.Printf("Failed to delete any resources: %v\n", results.err)
+				}
+				os.Exit(1)
+			} else if results.err == nil {
+				if results.singleKind != "" {
+					fmt.Printf("Successfully deleted %d '%s' resource(s)\n", results.numHandled, results.singleKind)
+				} else {
+					fmt.Printf("Successfully deleted %d resource(s)\n", results.numHandled)
+				}
+			} else {
+				fmt.Printf("Partial success: ")
+				if results.singleKind != "" {
+					fmt.Printf("deleted the first %d out of %d '%s' resources:\n",
+						results.numHandled, results.numResources, results.singleKind)
+				} else {
+					fmt.Printf("deleted the first %d out of %d resources:\n",
+						results.numHandled, results.numResources)
+				}
+				fmt.Printf("Hit error: %v\n", results.err)
+				os.Exit(1)
+			}
+		},
 	}
-}
+)

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -24,7 +24,6 @@ import (
 
 func init() {
 	deleteCommandArgs = newDeleteResourceArgs(DeleteCommand.Flags())
-	DeleteCommand.MarkFlagRequired("filename")
 }
 
 var (
@@ -76,7 +75,24 @@ var (
   failure deleting a specific resource it is possible to work out which
   resource failed based on the number of resources successfully deleted.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			results := executeConfigCommand(deleteCommandArgs.mapArgs(), actionDelete)
+			parsedArgs := deleteCommandArgs.mapArgs()
+			if len(args) < 1 {
+				if len(*deleteCommandArgs.filename) == 0 {
+					fmt.Println(`Example resource specifications include:
+   '-f rsrc.yaml'
+   '--filename=rsrc.json'
+   '<resource> <name>'
+   '<resource>'`)
+					os.Exit(1)
+				}
+			} else {
+				parsedArgs["<KIND>"] = args[0]
+				if len(args) > 1 {
+					parsedArgs["<NAME>"] = args[1]
+				}
+			}
+
+			results := executeConfigCommand(parsedArgs, actionDelete)
 			log.Infof("results: %+v", results)
 
 			if results.fileInvalid {

--- a/calicoctl/commands/ipam.go
+++ b/calicoctl/commands/ipam.go
@@ -15,49 +15,20 @@
 package commands
 
 import (
-	"fmt"
-	"os"
-	"strings"
+	"github.com/spf13/cobra"
 
-	"github.com/docopt/docopt-go"
-	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/ipam"
 )
 
-// IPAM takes keyword with an IP address then calls the subcommands.
-func IPAM(args []string) {
-	doc := constants.DatastoreIntro + `Usage:
-  calicoctl ipam <command> [<args>...]
-
-    release      Release a Calico assigned IP address.
-    show         Show details of a Calico assigned IP address.
-
-Options:
-  -h --help      Show this screen.
-
-Description:
-  IP Address Management specific commands for calicoctl.
-
-  See 'calicoctl ipam <command> --help' to read about a specific subcommand.
-`
-	arguments, err := docopt.Parse(doc, args, true, "", true, false)
-	if err != nil {
-		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
-		os.Exit(1)
-	}
-	if arguments["<command>"] == nil {
-		return
-	}
-
-	command := arguments["<command>"].(string)
-	args = append([]string{"ipam", command}, arguments["<args>"].([]string)...)
-
-	switch command {
-	case "release":
-		ipam.Release(args)
-	case "show":
-		ipam.Show(args)
-	default:
-		fmt.Println(doc)
-	}
+func init() {
+	IPAMCommand.AddCommand(ipam.ReleaseCommand)
+	IPAMCommand.AddCommand(ipam.ShowCommand)
 }
+
+var (
+	IPAMCommand = &cobra.Command{
+		Use:   "ipam",
+		Short: "IP Address Management",
+		Long:  "IP Address Management specific commands for calicoctl.",
+	}
+)

--- a/calicoctl/commands/ipam/args.go
+++ b/calicoctl/commands/ipam/args.go
@@ -1,0 +1,22 @@
+package ipam
+
+import (
+	flag "github.com/spf13/pflag"
+
+	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+)
+
+// ipamArgs defines the set of args for an ipam command
+type ipamArgs struct {
+	ip, config *string
+}
+
+// newIPAMArgs parses a flagset to generate a ipamArgs instance
+func newIPAMArgs(fs *flag.FlagSet) ipamArgs {
+	return ipamArgs{
+		ip: fs.String("ip", "", "Specifies the IP address to use"),
+		config: fs.StringP(
+			"config", "c", constants.DefaultConfigPath,
+			"Path to the file containing connection configuration in YAML or JSON format."),
+	}
+}

--- a/calicoctl/commands/ipam/show.go
+++ b/calicoctl/commands/ipam/show.go
@@ -18,69 +18,55 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
-	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/spf13/cobra"
 
-	docopt "github.com/docopt/docopt-go"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 )
 
-// IPAM takes keyword with an IP address then calls the subcommands.
-func Show(args []string) {
-	doc := constants.DatastoreIntro + `Usage:
-  calicoctl ipam show --ip=<IP> [--config=<CONFIG>]
-
-Options:
-  -h --help             Show this screen.
-     --ip=<IP>          IP address to show.
-  -c --config=<CONFIG>  Path to the file containing connection configuration in
-                        YAML or JSON format.
-                        [default: ` + constants.DefaultConfigPath + `]
-
-Description:
-  The ipam show command prints information about a given IP address, such as
-  special attributes defined for the IP or whether the IP has been reserved by
-  a user of the Calico IP Address Manager.
-`
-	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
-	if err != nil {
-		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
-		os.Exit(1)
-	}
-	if len(parsedArgs) == 0 {
-		return
-	}
-
-	ctx := context.Background()
-
-	// Create a new backend client from env vars.
-	cf := parsedArgs["--config"].(string)
-	client, err := clientmgr.NewClient(cf)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	ipamClient := client.IPAM()
-	passedIP := parsedArgs["--ip"].(string)
-	ip := argutils.ValidateIP(passedIP)
-	attr, err := ipamClient.GetAssignmentAttributes(ctx, ip)
-
-	// IP address is not assigned, this prints message like
-	// `IP 192.168.71.1 is not assigned in block`. This is not exactly an error,
-	// so not returning it to the caller.
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	// IP address is assigned with attributes.
-	if len(attr) != 0 {
-		fmt.Println(attr)
-	} else {
-		// IP address is assigned but attributes are not set.
-		fmt.Printf("No attributes defined for IP %s\n", ip)
-	}
+func init() {
+	ipamShowArgs = newIPAMArgs(ShowCommand.Flags())
+	ShowCommand.MarkFlagRequired("ip")
 }
+
+var (
+	ipamShowArgs ipamArgs
+	ShowCommand  = &cobra.Command{
+		Use:   "show",
+		Short: "Show details of a Calico assigned IP address.",
+		Long: `The ipam show command prints information about a given IP address, such as
+special attributes defined for the IP or whether the IP has been reserved by
+a user of the Calico IP Address Manager.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := context.Background()
+
+			// Create a new backend client from env vars.
+			client, err := clientmgr.NewClient(*ipamShowArgs.config)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+
+			ipamClient := client.IPAM()
+			ip := argutils.ValidateIP(*ipamShowArgs.ip)
+			attr, err := ipamClient.GetAssignmentAttributes(ctx, ip)
+
+			// IP address is not assigned, this prints message like
+			// `IP 192.168.71.1 is not assigned in block`. This is not exactly an error,
+			// so not returning it to the caller.
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+
+			// IP address is assigned with attributes.
+			if len(attr) != 0 {
+				fmt.Println(attr)
+			} else {
+				// IP address is assigned but attributes are not set.
+				fmt.Printf("No attributes defined for IP %s\n", ip)
+			}
+		},
+	}
+)

--- a/calicoctl/commands/node/diags.go
+++ b/calicoctl/commands/node/diags.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docopt/docopt-go"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	shutil "github.com/termie/go-shutil"
 )
 
@@ -37,19 +37,21 @@ type diagCmd struct {
 	filename string
 }
 
-// Diags function collects diagnostic information and logs
-func Diags(args []string) {
-	var err error
-	doc := `Usage:
-  calicoctl node diags [--log-dir=<LOG_DIR>]
+func init() {
+	DiagsCommand.Flags().StringVar(&logDir, "log-dir", "/var/log/calico", "The directory containing Calico logs.")
+}
 
-Options:
-  -h --help               Show this screen.
-     --log-dir=<LOG_DIR>  The directory containing Calico logs.
-                          [default: /var/log/calico]
+var (
+	logDir string
 
-Description:
-  This command is used to gather diagnostic information from a Calico node.
+	// DiagsCommand collects diagnostic information and logs
+	DiagsCommand = &cobra.Command{
+		Use: "diags",
+		//Options:
+		// -h --help               Show this screen.
+		//   --log-dir=<LOG_DIR>  The directory containing Calico logs.
+		//                       [default: /var/log/calico]
+		Long: `This command is used to gather diagnostic information from a Calico node.
   This is usually used when trying to diagnose an issue that may be related to
   your Calico network.
 
@@ -58,23 +60,15 @@ Description:
   uploaded files will be deleted after 14 days.
 
   This command must be run on the specific Calico node that you are gathering
-  diagnostics for.
-`
-
-	arguments, err := docopt.Parse(doc, args, true, "", false, false)
-	if err != nil {
-		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
-		os.Exit(1)
+  diagnostics for.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runDiags()
+		},
 	}
-	if len(arguments) == 0 {
-		return
-	}
-
-	runDiags(arguments["--log-dir"].(string))
-}
+)
 
 // runDiags takes logDir and runs a sequence of commands to collect diagnostics
-func runDiags(logDir string) {
+func runDiags() {
 
 	// Note: in for the cmd field in this struct, it  can't handle args quoted with space in it
 	// For example, you can't add cmd "do this", since after the `strings.Fields` it will become `"do` and `this"`

--- a/calicoctl/commands/node_darwin.go
+++ b/calicoctl/commands/node_darwin.go
@@ -17,10 +17,15 @@ package commands
 import (
 	"fmt"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // Node function is a switch to node related sub-commands
-func Node(args []string) {
-	fmt.Println("Error executing command: 'calicoctl node' commands are not available on this OS")
-	os.Exit(1)
+var NodeCommand = &cobra.Command{
+	Use: "node",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Error executing command: 'calicoctl node' commands are not available on this OS")
+		os.Exit(1)
+	},
 }

--- a/calicoctl/commands/node_linux.go
+++ b/calicoctl/commands/node_linux.go
@@ -15,57 +15,22 @@
 package commands
 
 import (
-	"fmt"
-	"os"
-	"strings"
+	"github.com/spf13/cobra"
 
-	"github.com/docopt/docopt-go"
-	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/node"
 )
 
-// Node function is a switch to node related sub-commands
-func Node(args []string) {
-	var err error
-	doc := constants.DatastoreIntro + `Usage:
-  calicoctl node <command> [<args>...]
-
-    run          Run the Calico node container image.
-    status       View the current status of a Calico node.
-    diags        Gather a diagnostics bundle for a Calico node.
-    checksystem  Verify the compute host is able to run a Calico node instance.
-
-Options:
-  -h --help      Show this screen.
-
-Description:
-  Node specific commands for calicoctl.  These commands must be run directly on
-  the compute host running the Calico node instance.
-
-  See 'calicoctl node <command> --help' to read about a specific subcommand.
-`
-	arguments, err := docopt.Parse(doc, args, true, "", true, false)
-	if err != nil {
-		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
-		os.Exit(1)
+var (
+	NodeCommand = &cobra.Command{
+		Use: "node",
+		Long: `Node specific commands for calicoctl.  These commands must be run directly on
+  the compute host running the Calico node instance.`,
 	}
-	if arguments["<command>"] == nil {
-		return
-	}
+)
 
-	command := arguments["<command>"].(string)
-	args = append([]string{"node", command}, arguments["<args>"].([]string)...)
-
-	switch command {
-	case "status":
-		node.Status(args)
-	case "diags":
-		node.Diags(args)
-	case "checksystem":
-		node.Checksystem(args)
-	case "run":
-		node.Run(args)
-	default:
-		fmt.Println(doc)
-	}
+func init() {
+	NodeCommand.AddCommand(node.RunCommand)
+	NodeCommand.AddCommand(node.StatusCommand)
+	NodeCommand.AddCommand(node.DiagsCommand)
+	NodeCommand.AddCommand(node.ChecksystemCommand)
 }

--- a/calicoctl/commands/node_windows.go
+++ b/calicoctl/commands/node_windows.go
@@ -17,10 +17,15 @@ package commands
 import (
 	"fmt"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // Node function is a switch to node related sub-commands
-func Node(args []string) {
-	fmt.Println("Error executing command: 'calicoctl node' commands are not available on this OS")
-	os.Exit(1)
+var NodeCommand = &cobra.Command{
+	Use: "node",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Error executing command: 'calicoctl node' commands are not available on this OS")
+		os.Exit(1)
+	},
 }

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -15,41 +15,29 @@
 package commands
 
 import (
-	"os"
-	"strings"
-
-	"github.com/docopt/docopt-go"
-
 	"fmt"
+	"os"
 
-	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
-func Replace(args []string) {
-	doc := constants.DatastoreIntro + `Usage:
-  calicoctl replace --filename=<FILENAME> [--config=<CONFIG>] [--namespace=<NS>]
+func init() {
+	replaceCommandArgs = newBaseResourceArgs(ReplaceCommand.Flags())
+	ReplaceCommand.MarkFlagRequired("filename")
+}
 
-Examples:
-  # Replace a policy using the data in policy.yaml.
+var (
+	replaceCommandArgs baseResourceArgs
+	ReplaceCommand     = &cobra.Command{
+		Use:   "replace",
+		Short: "Replace a Calico resource",
+		Example: `# Replace a policy using the data in policy.yaml.
   calicoctl replace -f ./policy.yaml
 
   # Replace a policy based on the JSON passed into stdin.
-  cat policy.json | calicoctl replace -f -
-
-Options:
-  -h --help                  Show this screen.
-  -f --filename=<FILENAME>   Filename to use to replace the resource.  If set
-                             to "-" loads from stdin.
-  -c --config=<CONFIG>       Path to the file containing connection
-                             configuration in YAML or JSON format.
-                             [default: ` + constants.DefaultConfigPath + `]
-  -n --namespace=<NS>       Namespace of the resource.
-                            Only applicable to NetworkPolicy and WorkloadEndpoint.
-                            Uses the default namespace if not specified.
-
-Description:
-  The replace command is used to replace a set of resources by filename or
+  cat policy.json | calicoctl replace -f -`,
+		Long: `The replace command is used to replace a set of resources by filename or
   stdin.  JSON and YAML formats are accepted.
 
   Valid resource types are:
@@ -77,50 +65,43 @@ Description:
   resource failed based on the number of resources successfully replaced.
 
   When replacing a resource, the complete resource spec must be provided, it is
-  not sufficient to supply only the fields that are being updated.
-`
-	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
-	if err != nil {
-		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
-		os.Exit(1)
-	}
-	if len(parsedArgs) == 0 {
-		return
-	}
+  not sufficient to supply only the fields that are being updated.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			results := executeConfigCommand(replaceCommandArgs.mapArgs(), actionUpdate)
+			log.Infof("results: %+v", results)
 
-	results := executeConfigCommand(parsedArgs, actionUpdate)
-	log.Infof("results: %+v", results)
-
-	if results.fileInvalid {
-		fmt.Printf("Failed to execute command: %v\n", results.err)
-		os.Exit(1)
-	} else if results.numHandled == 0 {
-		if results.numResources == 0 {
-			fmt.Printf("No resources specified in file\n")
-		} else if results.numResources == 1 {
-			fmt.Printf("Failed to replace '%s' resource: %v\n", results.singleKind, results.err)
-		} else if results.singleKind != "" {
-			fmt.Printf("Failed to replace any '%s' resources: %v\n", results.singleKind, results.err)
-		} else {
-			fmt.Printf("Failed to replace any resources: %v\n", results.err)
-		}
-		os.Exit(1)
-	} else if results.err == nil {
-		if results.singleKind != "" {
-			fmt.Printf("Successfully replaced %d '%s' resource(s)\n", results.numHandled, results.singleKind)
-		} else {
-			fmt.Printf("Successfully replaced %d resource(s)\n", results.numHandled)
-		}
-	} else {
-		fmt.Printf("Partial success: ")
-		if results.singleKind != "" {
-			fmt.Printf("replaced the first %d out of %d '%s' resources:\n",
-				results.numHandled, results.numResources, results.singleKind)
-		} else {
-			fmt.Printf("replaced the first %d out of %d resources:\n",
-				results.numHandled, results.numResources)
-		}
-		fmt.Printf("Hit error: %v\n", results.err)
-		os.Exit(1)
+			if results.fileInvalid {
+				fmt.Printf("Failed to execute command: %v\n", results.err)
+				os.Exit(1)
+			} else if results.numHandled == 0 {
+				if results.numResources == 0 {
+					fmt.Printf("No resources specified in file\n")
+				} else if results.numResources == 1 {
+					fmt.Printf("Failed to replace '%s' resource: %v\n", results.singleKind, results.err)
+				} else if results.singleKind != "" {
+					fmt.Printf("Failed to replace any '%s' resources: %v\n", results.singleKind, results.err)
+				} else {
+					fmt.Printf("Failed to replace any resources: %v\n", results.err)
+				}
+				os.Exit(1)
+			} else if results.err == nil {
+				if results.singleKind != "" {
+					fmt.Printf("Successfully replaced %d '%s' resource(s)\n", results.numHandled, results.singleKind)
+				} else {
+					fmt.Printf("Successfully replaced %d resource(s)\n", results.numHandled)
+				}
+			} else {
+				fmt.Printf("Partial success: ")
+				if results.singleKind != "" {
+					fmt.Printf("replaced the first %d out of %d '%s' resources:\n",
+						results.numHandled, results.numResources, results.singleKind)
+				} else {
+					fmt.Printf("replaced the first %d out of %d resources:\n",
+						results.numHandled, results.numResources)
+				}
+				fmt.Printf("Hit error: %v\n", results.err)
+				os.Exit(1)
+			}
+		},
 	}
-}
+)

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -28,7 +28,7 @@ import (
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/resourcemgr"
-	yaml "github.com/projectcalico/go-yaml-wrapper"
+	"github.com/projectcalico/go-yaml-wrapper"
 	client "github.com/projectcalico/libcalico-go/lib/clientv3"
 	calicoErrors "github.com/projectcalico/libcalico-go/lib/errors"
 )
@@ -120,7 +120,7 @@ func executeConfigCommand(args map[string]interface{}, action action) commandRes
 
 	log.Info("Executing config command")
 
-	if filename := args["--filename"]; filename != nil {
+	if filename := args["--filename"]; filename != nil && len(filename.(string)) > 0 {
 		// Filename is specified, load the resource from file and convert to a slice
 		// of resources for easier handling.
 		if r, err = resourcemgr.CreateResourcesFromFile(filename.(string)); err != nil {

--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -26,11 +26,12 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/options"
 )
 
-var VERSION, BUILD_DATE, GIT_REVISION string
+var VERSION, GIT_REVISION string
 var VERSION_SUMMARY string
+var BUILD_DATE string // unused
 
 func init() {
-	VERSION_SUMMARY = "calicoctl version " + VERSION + ", build " + GIT_REVISION
+	VERSION_SUMMARY = VERSION + "-" + GIT_REVISION
 }
 
 func Version(args []string) {
@@ -55,9 +56,7 @@ Description:
 		return
 	}
 
-	fmt.Println("Client Version:   ", VERSION)
-	fmt.Println("Build date:       ", BUILD_DATE)
-	fmt.Println("Git commit:       ", GIT_REVISION)
+	fmt.Println("Client Version:   ", VERSION_SUMMARY)
 
 	// Load the client config and connect.
 	cf := parsedArgs["--config"].(string)

--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -26,13 +26,8 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/options"
 )
 
-var VERSION, GIT_REVISION string
-var VERSION_SUMMARY string
-var BUILD_DATE string // unused
-
-func init() {
-	VERSION_SUMMARY = VERSION + "-" + GIT_REVISION
-}
+var VERSION string
+var BUILD_DATE, GIT_REVISION string // unused
 
 func Version(args []string) {
 	doc := `Usage:
@@ -56,7 +51,7 @@ Description:
 		return
 	}
 
-	fmt.Println("Client Version:   ", VERSION_SUMMARY)
+	fmt.Println("Client Version:   ", VERSION)
 
 	// Load the client config and connect.
 	cf := parsedArgs["--config"].(string)

--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -18,64 +18,53 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
-	"github.com/docopt/docopt-go"
+	"github.com/spf13/cobra"
+
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/libcalico-go/lib/options"
 )
 
-var VERSION string
-var BUILD_DATE, GIT_REVISION string // unused
+var (
+	VERSION                  string
+	BUILD_DATE, GIT_REVISION string // unused
+	cf                       = constants.DefaultConfigPath
+)
 
-func Version(args []string) {
-	doc := `Usage:
-  calicoctl version [--config=<CONFIG>]
+func init() {
+	VersionCommand.Flags().StringVarP(&cf, "config", "c", constants.DefaultConfigPath, "Path to the file containing connection configuration in YAML or JSON format.")
+}
 
-Options:
-  -h --help             Show this screen.
-  -c --config=<CONFIG>  Path to the file containing connection configuration in
-                        YAML or JSON format.
-                        [default: ` + constants.DefaultConfigPath + `]
+var VersionCommand = &cobra.Command{
+	Use:   "version",
+	Short: "Display the version of calicoctl",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Client Version:   ", VERSION)
 
-Description:
-  Display the version of calicoctl.
-`
-	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
-	if err != nil {
-		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
-		os.Exit(1)
-	}
-	if len(parsedArgs) == 0 {
-		return
-	}
+		// Load the client config and connect.
+		client, err := clientmgr.NewClient(cf)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		ctx := context.Background()
+		ci, err := client.ClusterInformation().Get(ctx, "default", options.GetOptions{})
+		if err != nil {
+			fmt.Println("Unable to retrieve Cluster Version or Type: ", err)
+			os.Exit(1)
+		}
 
-	fmt.Println("Client Version:   ", VERSION)
+		v := ci.Spec.CalicoVersion
+		if v == "" {
+			v = "unknown"
+		}
+		t := ci.Spec.ClusterType
+		if t == "" {
+			t = "unknown"
+		}
 
-	// Load the client config and connect.
-	cf := parsedArgs["--config"].(string)
-	client, err := clientmgr.NewClient(cf)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	ctx := context.Background()
-	ci, err := client.ClusterInformation().Get(ctx, "default", options.GetOptions{})
-	if err != nil {
-		fmt.Println("Unable to retrieve Cluster Version or Type: ", err)
-		os.Exit(1)
-	}
-
-	v := ci.Spec.CalicoVersion
-	if v == "" {
-		v = "unknown"
-	}
-	t := ci.Spec.ClusterType
-	if t == "" {
-		t = "unknown"
-	}
-
-	fmt.Println("Cluster Version:  ", v)
-	fmt.Println("Cluster Type:     ", t)
+		fmt.Println("Cluster Version:  ", v)
+		fmt.Println("Cluster Type:     ", t)
+	},
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 98f26f77e73088b84c7b6c3caa10062d5c8beb14140a5c4b965e2518c954df32
-updated: 2018-09-07T15:23:36.932481188Z
+hash: b335fc9a8b5d65c03331ac062f5194579beefb6573bafca2f2fe59af38ade774
+updated: 2018-09-07T13:58:21.683697899-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -109,6 +109,8 @@ imports:
   - json/token
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
+- name: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/influxdata/influxdb
   version: 375eddebb83c3f2d198d7a029363eeadc28f5a60
   subpackages:
@@ -273,6 +275,8 @@ imports:
   - mem
 - name: github.com/spf13/cast
   version: 8965335b8c7107321228e3e3702cab9832751bac
+- name: github.com/spf13/cobra
+  version: 99dc123558852f67743bd0b2caf8383cb3c6d720
 - name: github.com/spf13/jwalterweatherman
   version: 7c0cea34c8ece3fbeb2b27ab9b59511d360fb394
 - name: github.com/spf13/pflag

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,6 +6,7 @@ import:
 - package: github.com/mcuadros/go-version
 - package: github.com/olekukonko/tablewriter
 - package: github.com/spf13/cobra
+- package: github.com/spf13/pflag
 - package: github.com/osrg/gobgp
   version: v1.22
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,6 +5,7 @@ import:
 - package: github.com/docopt/docopt-go
 - package: github.com/mcuadros/go-version
 - package: github.com/olekukonko/tablewriter
+- package: github.com/spf13/cobra
 - package: github.com/osrg/gobgp
   version: v1.22
   subpackages:


### PR DESCRIPTION
## Description
This is a pretty nasty looking PR so I apologize, but I promise it isn't as bad as the github diff viewer is making it look; none of the actual functionality was changed, just the command-line interface parts. 
The main bulk of the change comes from the `args.go` file that defines the arguments for each command and the flags that they receive.
It seems like the default behavior for most if not all flags was to return blank (for strings) or false (for bools) which the cobra replacement provides pretty nicely.
If it passes the ci tests, that means it's good to go, right? 😉 

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note
```release-note
Replaced docopt with spf13/cobra for command-line argument parsing
```
