### PR TITLE
Fix panic in node status when process is terminated

### DIFF
--- a/calicoctl/commands/node/status.go
+++ b/calicoctl/commands/node/status.go
@@ -103,7 +103,10 @@ func psContains(proc []string, procList []*process.Process) bool {
 	for _, p := range procList {
 		cmds, err := p.CmdlineSlice()
 		if err != nil {
-			panic(err)
+			// Failed to get CLI arguments for this process.
+			// Maybe it doesn't exist any more - move on to the next one.
+			log.WithError(err).Debug("Error getting CLI arguments")
+			continue
 		}
 		var match bool
 		for i, p := range proc {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We were panicking when we hit an error getting CLI args for a process. However, that included times when the process terminated between listing the processes and looking up the CLI args.

This PR handles that case more gracefully. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix calicoctl node status handling of terminated processes
```
