### PR TITLE
Support calicoctl --version

### DIFF
--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -53,7 +53,7 @@ Description:
 
   See 'calicoctl <command> --help' to read about a specific subcommand.
 `
-	arguments, _ := docopt.Parse(doc, nil, true, "", true, false)
+	arguments, _ := docopt.Parse(doc, nil, true, commands.VERSION_SUMMARY, true, false)
 
 	if logLevel := arguments["--log-level"]; logLevel != nil {
 		parsedLogLevel, err := log.ParseLevel(logLevel.(string))


### PR DESCRIPTION
We already support 'calicoctl version', which prints information like
this:

    Client Version:    v3.4.0-0.dev-15-g553bb080-dirty
    Git commit:        553bb080
    no etcd endpoints specified

However we don't support the standard 'calicoctl --version', and it
would be better if we did.  (Even our own Makefiles expect this; see
https://github.com/projectcalico/node/blob/master/Makefile#L459)

With this change, 'calicoctl --version' will print information likes
this:

    calicoctl version v3.4.0-0.dev-15-g553bb080-dirty, build 553bb080

We could refactor more to make this output the same as 'calicoctl
version', but I think this is good enough as is and that the further
work isn't clearly justified.
