### PR TITLE
Improve 'calicoctl --version' output

### DIFF
--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -30,8 +30,7 @@ var VERSION, GIT_REVISION string
 var VERSION_SUMMARY string
 
 func init() {
-	VERSION_SUMMARY = "calicoctl " + VERSION + ", build " + GIT_REVISION + `
-Run 'calicoctl version' to see cluster version information as well.`
+	VERSION_SUMMARY = `Run 'calicoctl version' to see version information.`
 }
 
 func Version(args []string) {

--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -30,7 +30,8 @@ var VERSION, GIT_REVISION string
 var VERSION_SUMMARY string
 
 func init() {
-	VERSION_SUMMARY = "calicoctl version " + VERSION + ", build " + GIT_REVISION
+	VERSION_SUMMARY = "calicoctl " + VERSION + ", build " + GIT_REVISION + `
+Run 'calicoctl version' to see cluster version information as well.`
 }
 
 func Version(args []string) {


### PR DESCRIPTION
Output is like this:
```
calicoctl v3.4.0-0.dev-18-g338531f8, build 338531f8
Run 'calicoctl version' to see cluster version information as well.
```