### PR TITLE
Remove TTY and interactive flags from build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ bin/calicoctl-linux-%: OS=linux
 bin/calicoctl-%: $(CALICOCTL_FILES) vendor
 	mkdir -p bin
 	-mkdir -p .go-pkg-cache
-	docker run --rm -ti \
+	docker run --rm \
 	  -e OS=$(OS) -e ARCH=$(ARCH) \
 	  -e GOOS=$(OS) -e GOARCH=$(ARCH) \
 	  -e CALICOCTL_GIT_REVISION=$(CALICOCTL_GIT_REVISION) \


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
These flags prevent CI from building as it does not have TTY. Also, it does not need to be interactive.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
