### PR TITLE
Automated cherry pick of #1942: Specify GitHub organization in release-publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -455,7 +455,7 @@ release-publish: release-prereqs
 	# Push binaries to GitHub release.
 	# Requires ghr: https://github.com/tcnksm/ghr
 	# Requires GITHUB_TOKEN environment variable set.
-	ghr -r calicoctl \
+	ghr -u projectcalico -r calicoctl \
 		-b "Release notes can be found at https://docs.projectcalico.org" \
 		-n $(VERSION) \
 		$(VERSION) ./bin/


### PR DESCRIPTION
Cherry pick of #1942 on release-v3.4.

#1942: Specify GitHub organization in release-publish