### PR TITLE
fix label command panic when resource has no label

### DIFF
--- a/calicoctl/commands/label.go
+++ b/calicoctl/commands/label.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/docopt/docopt-go"
+	docopt "github.com/docopt/docopt-go"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/resourcemgr"
 
@@ -139,6 +139,9 @@ Description:
 	overwrite := parsedArgs["--overwrite"].(bool)
 	overwritten := false
 	client := results.client
+	if labels == nil {
+		labels = make(map[string]string)
+	}
 
 	if remove {
 		// remove label.

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -855,6 +855,25 @@ class TestCalicoctlCommands(TestBase):
         rev4 = rc.decoded
         self.assertEqual(rev1_labels,rev4['metadata']['labels'])
 
+        # test adding label for resources with no labels.
+        rc = calicoctl("create",data=node_name1_rev1)
+        rc.assert_no_error()
+
+        rc = calicoctl("label nodes node1 cluster=frontend")
+        rc.assert_no_error()
+
+        rc = calicoctl("get nodes node1 -o yaml")
+        rc.assert_no_error()
+        node1_rev2 = rc.decoded
+        self.assertEqual("frontend",node1_rev2['metadata']['labels']['cluster'])
+
+        # test removing labels on resources with no labels
+        rc = calicoctl("apply",data=node_name1_rev1)
+        rc.assert_no_error()
+        rc = calicoctl("label nodes node1 cluster --remove")
+        rc.assert_error("can not remove label")
+
+
 
 
 #


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
fix `calicoctl label` command panic on nil map dereference when resource has no labels.
Sorry for the bug imported in #1950. 
## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
