### PR TITLE
Catch and exit on bad command-line flags

### DIFF
--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -55,7 +55,6 @@ Description:
   See 'calicoctl <command> --help' to read about a specific subcommand.
 `
 	arguments, err := docopt.Parse(doc, nil, true, commands.VERSION_SUMMARY, true, false)
-
 	if err != nil {
 		if _, ok := err.(*docopt.UserError); ok {
 			// the user gave us bad input

--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@ package main
 
 import (
 	"fmt"
-
 	"os"
+	"strings"
 
 	"github.com/docopt/docopt-go"
 	"github.com/projectcalico/calicoctl/calicoctl/commands"
@@ -54,7 +54,15 @@ Description:
 
   See 'calicoctl <command> --help' to read about a specific subcommand.
 `
-	arguments, _ := docopt.Parse(doc, nil, true, commands.VERSION_SUMMARY, true, false)
+	arguments, err := docopt.Parse(doc, nil, true, commands.VERSION_SUMMARY, true, false)
+
+	if err != nil {
+		if _, ok := err.(*docopt.UserError); ok {
+			// the user gave us bad input
+			fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(os.Args[1:], " "))
+		}
+		os.Exit(1)
+	}
 
 	if logLevel := arguments["--log-level"]; logLevel != nil {
 		parsedLogLevel, err := log.ParseLevel(logLevel.(string))

--- a/tests/st/calicoctl/test_flags.py
+++ b/tests/st/calicoctl/test_flags.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2015-2019 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tests.st.test_base import TestBase
+from tests.st.utils.utils import calicoctl
+
+class TestCalicoctlCLIFlags(TestBase):
+    """
+    Test calicoctl command-line flags
+    """
+
+    def test_usage(self):
+        """
+        Test usage successfully
+        """
+        rc = calicoctl("-h")
+        rc.assert_no_error()
+
+    def test_bad_flags(self):
+        """
+        Test bad flags unsuccessfully
+        """
+        # no -m flag
+        rc = calicoctl("-m")
+        rc.assert_error(text="Invalid option: 'calicoctl -m'.")
+        # no --unknown-flag flag
+        rc = calicoctl("--unknown-flag")
+        rc.assert_error(text="Invalid option: 'calicoctl --unknown-flag'.")
+


### PR DESCRIPTION
## Description

Addresses #1910. This fix looks for the returning `err` and exits if present.

If the `err` is a `UserError`, we remind the user of the `--help` option.

I tested positive and negative tests and added some checks to the Python scripts.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
calicoctl will now return a non-zero exit code when passed an unknown flag
```
