### PR TITLE
clean out go-pkg-cache during

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ LIBCALICOGO_PATH?=none
 ## Clean enough that a new release build will be clean
 clean:
 	find . -name '*.created-$(ARCH)' -exec rm -f {} +
-	rm -rf bin build certs *.tar vendor
+	rm -rf bin build certs *.tar vendor .go-pkg-cache
 	docker rmi $(BUILD_IMAGE):latest-$(ARCH) || true
 	docker rmi $(BUILD_IMAGE):$(VERSION)-$(ARCH) || true
 ifeq ($(ARCH),amd64)


### PR DESCRIPTION
## Description
Clear `.go-pkg-cache` during a `make clean`.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
