### PR TITLE
Allow delete/get to specify multiple names

### DIFF
--- a/calicoctl/commands/argutils/args.go
+++ b/calicoctl/commands/argutils/args.go
@@ -23,6 +23,16 @@ func ArgStringOrBlank(args map[string]interface{}, argName string) string {
 	return ""
 }
 
+// ArgStringsOrBlank returns the requested argument as a []string, or as a
+// []string{""} if the argument is not present.
+func ArgStringsOrBlank(args map[string]interface{}, argName string) []string {
+	val := args[argName].([]string)
+	if len(val) > 0 {
+		return val
+	}
+	return []string{""}
+}
+
 // ArgBoolOrFalse returns the requested argument as a boolean, or as false
 // if the argument is not present.
 func ArgBoolOrFalse(args map[string]interface{}, argName string) bool {

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -30,7 +30,7 @@ import (
 
 func Get(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl get ( (<KIND> [<NAME>]) |
+  calicoctl get ( (<KIND> [<NAME>...]) |
                 --filename=<FILENAME>)
                 [--output=<OUTPUT>] [--config=<CONFIG>] [--namespace=<NS>] [--all-namespaces] [--export]
 
@@ -38,8 +38,8 @@ Examples:
   # List all policy in default output format.
   calicoctl get policy
 
-  # List a specific policy in YAML format
-  calicoctl get -o yaml policy my-policy-1
+  # List a specific policies in YAML format
+  calicoctl get -o yaml policy my-policy-1 my-policy-2
 
 Options:
   -h --help                    Show this screen.
@@ -193,5 +193,13 @@ Description:
 	err = rp.print(results.client, results.resources)
 	if err != nil {
 		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if len(results.resErrs) > 0 {
+		for _, err := range results.resErrs {
+			fmt.Fprintf(os.Stderr, "%+v\n", err)
+		}
+		os.Exit(1)
 	}
 }

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -100,6 +100,9 @@ type commandResults struct {
 	// The results returned from each invocation
 	resources []runtime.Object
 
+	// Errors associated with individual resources
+	resErrs []error
+
 	// The Calico API client used for the requests (useful if required
 	// again).
 	client client.Interface
@@ -114,16 +117,17 @@ type commandResults struct {
 // 	-  Process each resource individually, fanning out to the appropriate methods on
 //	   the client interface, collate results and exit on the first error.
 func executeConfigCommand(args map[string]interface{}, action action) commandResults {
-	var r interface{}
-	var err error
 	var resources []resourcemgr.ResourceObject
+
+	singleKind := false
 
 	log.Info("Executing config command")
 
 	if filename := args["--filename"]; filename != nil {
 		// Filename is specified, load the resource from file and convert to a slice
 		// of resources for easier handling.
-		if r, err = resourcemgr.CreateResourcesFromFile(filename.(string)); err != nil {
+		r, err := resourcemgr.CreateResourcesFromFile(filename.(string))
+		if err != nil {
 			return commandResults{err: err, fileInvalid: true}
 		}
 
@@ -131,16 +135,17 @@ func executeConfigCommand(args map[string]interface{}, action action) commandRes
 		if err != nil {
 			return commandResults{err: err}
 		}
-	} else if r, err := resourcemgr.GetResourceFromArgs(args); err != nil {
+	} else {
 		// Filename is not specific so extract the resource from the arguments. This
 		// is only useful for delete and get functions - but we don't need to check that
 		// here since the command syntax requires a filename for the other resource
 		// management commands.
-		return commandResults{err: err}
-	} else {
-		// We extracted a single resource type with identifiers from the CLI, convert to
-		// a list for simpler handling.
-		resources = []resourcemgr.ResourceObject{r}
+		var err error
+		singleKind = true
+		resources, err = resourcemgr.GetResourcesFromArgs(args)
+		if err != nil {
+			return commandResults{err: err}
+		}
 	}
 
 	if len(resources) == 0 {
@@ -178,25 +183,37 @@ func executeConfigCommand(args map[string]interface{}, action action) commandRes
 		count[kind] = count[kind] + 1
 		results.numResources = results.numResources + 1
 	}
-	if len(count) == 1 {
+	if len(count) == 1 || singleKind {
 		results.singleKind = kind
 	}
 
 	// Now execute the command on each resource in order, exiting as soon as we hit an
 	// error.
 	export := argutils.ArgBoolOrFalse(args, "--export")
-	nameSpecified := argutils.ArgStringOrBlank(args, "<NAME>")
+	nameSpecified := false
+	switch a := args["<NAME>"].(type) {
+	case string:
+		nameSpecified = len(a) > 0
+	case []string:
+		nameSpecified = len(a) > 0
+	}
 	for _, r := range resources {
 		res, err := executeResourceAction(args, client, r, action)
 		if err != nil {
-			results.err = err
-			break
+			switch action {
+			case actionDelete, actionGetOrList:
+				results.resErrs = append(results.resErrs, err)
+				continue
+			default:
+				results.err = err
+				break
+			}
 		}
 
 		// Remove the cluster specific metadata if the "--export" flag is specified
 		// Skip removing cluster specific metadata if this is is called as a "list"
 		// operation (no specific name is specified).
-		if export && nameSpecified != "" {
+		if export && nameSpecified {
 			for i, _ := range res {
 				rom := res[i].(v1.ObjectMetaAccessor).GetObjectMeta()
 				rom.SetNamespace("")

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -191,12 +191,26 @@ func executeConfigCommand(args map[string]interface{}, action action) commandRes
 	// error.
 	export := argutils.ArgBoolOrFalse(args, "--export")
 	nameSpecified := false
+	emptyName := false
 	switch a := args["<NAME>"].(type) {
 	case string:
 		nameSpecified = len(a) > 0
+		_, ok := args["<NAME>"]
+		emptyName = !ok || !nameSpecified
 	case []string:
 		nameSpecified = len(a) > 0
+		for _, v := range a {
+			if v == "" {
+				emptyName = true
+			}
+		}
 	}
+
+	if emptyName {
+		fmt.Printf("resource name may not be empty\n")
+		os.Exit(1)
+	}
+
 	for _, r := range resources {
 		res, err := executeResourceAction(args, client, r, action)
 		if err != nil {

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -149,6 +149,15 @@ class TestCalicoctlCommands(TestBase):
         rc.assert_no_error()
         rc.assert_output_equals(rcYaml.output)
 
+    def test_reject_unknown_resource(self):
+        """
+        Test that we error if a resource is not know
+        """
+
+        rc = calicoctl("get somekind somename")
+        rc.assert_error()
+        rc.assert_output_contains("Failed to get resources: resource type 'somekind' is not supported")
+
     def test_delete_with_resource_version(self):
         """
         Test that resource version operates correctly with delete, i.e.

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -158,6 +158,26 @@ class TestCalicoctlCommands(TestBase):
         rc.assert_error()
         rc.assert_output_contains("Failed to get resources: resource type 'somekind' is not supported")
 
+    def test_empty_name_is_ilegal(self):
+        """
+        Test that we error if empty name is provided
+        """
+
+        rc = calicoctl("get policy \"\"")
+        rc.assert_error()
+
+        rc = calicoctl("get policy x \"\" y")
+        rc.assert_error()
+
+        rc = calicoctl("get delete \"\"")
+        rc.assert_error()
+
+        rc = calicoctl("get delete x \"\" y")
+        rc.assert_error()
+
+        rc = calicoctl("get label \"\" key --remove")
+        rc.assert_error()
+
     def test_delete_with_resource_version(self):
         """
         Test that resource version operates correctly with delete, i.e.

--- a/tests/st/utils/data.py
+++ b/tests/st/utils/data.py
@@ -85,6 +85,12 @@ ippool_name2_rev1_v6 = {
     }
 }
 
+ippool_name2_rev1_table = (
+    "NAME           CIDR             SELECTOR   \n"
+    "ippool-name2   fed0:8001::/64   all()"
+)
+
+
 #
 # BGPPeers
 #


### PR DESCRIPTION
On get/delete do not fail with the first failing resource. To be more
in line with kubectl, keep going, report success where appropriate
and report errors for failing resources. If there was any error,
calicoctl has non-zero exit status.

fixes OS-3934
fixes #1796 

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
calicoctl get/delete per resource type can take multiple names
```
