### PR TITLE
Fixed missing new line in get errors

### DIFF
--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -188,8 +188,11 @@ Description:
 
 	if len(results.resErrs) > 0 {
 		var errStr string
-		for _, err := range results.resErrs {
+		for i, err := range results.resErrs {
 			errStr += err.Error()
+			if (i + 1) != len(results.resErrs) {
+				errStr += "\n"
+			}
 		}
 		return fmt.Errorf(errStr)
 	}


### PR DESCRIPTION
Missing new line when there is multiple errors in get

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

fixes 

```
tomas@tomas:~/go/src/github.com/projectcalico/calicoctl (tomas-ipam-show-fix-exit-status)$ DATASTORE_TYPE=kubernetes KUBECONFIG=~/.kube/config bin/calicoctl-linux-amd64 get policy x y z
resource does not exist: NetworkPolicy(default/default.x) with error: networkpolicies.crd.projectcalico.org "default.x" not foundresource does not exist: NetworkPolicy(default/default.y) with error: networkpolicies.crd.projectcalico.org "default.y" not foundresource does not exist: NetworkPolicy(default/default.z) with error: networkpolicies.crd.projectcalico.org "default.z" not found
```
as

```
tomas@tomas:~/go/src/github.com/projectcalico/calicoctl (tomas-fix-missing-new-lines)$ DATASTORE_TYPE=kubernetes KUBECONFIG=~/.kube/config bin/calicoctl-linux-amd64 get policy x y z
resource does not exist: NetworkPolicy(default/default.x) with error: networkpolicies.crd.projectcalico.org "default.x" not found
resource does not exist: NetworkPolicy(default/default.y) with error: networkpolicies.crd.projectcalico.org "default.y" not found
resource does not exist: NetworkPolicy(default/default.z) with error: networkpolicies.crd.projectcalico.org "default.z" not found
```

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
