### PR TITLE
Fix regression in reporting errors in ipam show

### DIFF
--- a/calicoctl/commands/ipam/show.go
+++ b/calicoctl/commands/ipam/show.go
@@ -69,7 +69,8 @@ Description:
 	// `IP 192.168.71.1 is not assigned in block`. This is not exactly an error,
 	// so not returning it to the caller.
 	if err != nil {
-		return err
+		fmt.Println(err)
+		return nil
 	}
 
 	// IP address is assigned with attributes.


### PR DESCRIPTION
Do not return error code in ipam show if ip does not exist

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

```
DATASTORE_TYPE=kubernetes KUBECONFIG=~/.kube/config bin/calicoctl-linux-amd64 ipam show --ip=1.1.1.1
echo $?
1
```

is back to 

```
DATASTORE_TYPE=kubernetes KUBECONFIG=~/.kube/config bin/calicoctl-linux-amd64 ipam show --ip=1.1.1.1
echo $?
0
```



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
