### PR TITLE
Setting defaults before validation for resources

### DIFF
--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -400,6 +400,7 @@ func unmarshalResource(tm unstructured.Unstructured, b []byte) ([]runtime.Object
 		return nil, err
 	}
 
+	// Setting default values to resource before un marshalling
 	defaults.SetDefaults(unpacked)
 	if err = yaml.UnmarshalStrict(b, unpacked); err != nil {
 		return nil, err
@@ -429,10 +430,12 @@ func unmarshalSliceOfResources(tml []unstructured.Unstructured, b []byte) ([]run
 		if err != nil {
 			return nil, err
 		}
+
 		unpacked[i] = r
+		// Setting default values to resource before un marshalling
+		defaults.SetDefaults(unpacked[i])
 	}
 
-	defaults.SetDefaults(unpacked)
 	if err := yaml.UnmarshalStrict(b, &unpacked); err != nil {
 		return nil, err
 	}

--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	defaults "github.com/mcuadros/go-defaults"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	yamlsep "github.com/projectcalico/calicoctl/calicoctl/util/yaml"
 	yaml "github.com/projectcalico/go-yaml-wrapper"
@@ -403,6 +404,7 @@ func unmarshalResource(tm unstructured.Unstructured, b []byte) ([]runtime.Object
 		return nil, err
 	}
 
+	defaults.SetDefaults(unpacked)
 	log.Infof("Type of unpacked data: %v", reflect.TypeOf(unpacked))
 	if err = validator.Validate(unpacked); err != nil {
 		return nil, err
@@ -434,6 +436,7 @@ func unmarshalSliceOfResources(tml []unstructured.Unstructured, b []byte) ([]run
 		return nil, err
 	}
 
+	defaults.SetDefaults(unpacked)
 	// Validate the data in the structures.  The validator does not handle slices, so
 	// validate each resource separately.
 	for _, r := range unpacked {

--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2015-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -400,11 +400,11 @@ func unmarshalResource(tm unstructured.Unstructured, b []byte) ([]runtime.Object
 		return nil, err
 	}
 
+	defaults.SetDefaults(unpacked)
 	if err = yaml.UnmarshalStrict(b, unpacked); err != nil {
 		return nil, err
 	}
 
-	defaults.SetDefaults(unpacked)
 	log.Infof("Type of unpacked data: %v", reflect.TypeOf(unpacked))
 	if err = validator.Validate(unpacked); err != nil {
 		return nil, err
@@ -432,11 +432,11 @@ func unmarshalSliceOfResources(tml []unstructured.Unstructured, b []byte) ([]run
 		unpacked[i] = r
 	}
 
+	defaults.SetDefaults(unpacked)
 	if err := yaml.UnmarshalStrict(b, &unpacked); err != nil {
 		return nil, err
 	}
 
-	defaults.SetDefaults(unpacked)
 	// Validate the data in the structures.  The validator does not handle slices, so
 	// validate each resource separately.
 	for _, r := range unpacked {

--- a/calicoctl/resourcemgr/resourcemgr_test.go
+++ b/calicoctl/resourcemgr/resourcemgr_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/projectcalico/calicoctl/calicoctl/resourcemgr"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	IppoolV6WithNeverVxlan = `kind: IPPool
+apiVersion: projectcalico.org/v3
+metadata:
+  name: my-ippool
+spec:
+  cidr: 2002::/64
+  ipipMode: Never
+  vxlanMode: Never
+  natOutgoing: true
+`
+	IppoolV6MissingVxlan = `kind: IPPool
+apiVersion: projectcalico.org/v3
+metadata:
+  name: my-ippool
+spec:
+  cidr: 2002::/64
+  ipipMode: Never
+  natOutgoing: true
+`
+	IppoolV4WithAlwaysVxlan = `kind: IPPool
+apiVersion: projectcalico.org/v3
+metadata:
+  name: my-ippool
+spec:
+  cidr: 192.168.0.0/16
+  ipipMode: Never
+  vxlanMode: Always
+  natOutgoing: true
+`
+	IppoolV6WithAlwaysVxlan = `kind: IPPool
+apiVersion: projectcalico.org/v3
+metadata:
+  name: my-ippool
+spec:
+  cidr: 2002::/64
+  ipipMode: Never
+  vxlanMode: Always
+  natOutgoing: true
+`
+	IppoolV6WithErrorVxlan = `kind: IPPool
+apiVersion: projectcalico.org/v3
+metadata:
+  name: my-ippool
+spec:
+  cidr: 2002::/64
+  ipipMode: Never
+  vxlanMode: NotDefined
+  natOutgoing: true
+`
+	IppoolV6WithBothIPIPAndVxlan = `kind: IPPool
+apiVersion: projectcalico.org/v3
+metadata:
+  name: my-ippool
+spec:
+  cidr: 2002::/64
+  ipipMode: Always
+  vxlanMode: Always
+  natOutgoing: true
+`
+	IppoolV4WithBothIPIPAndVxlan = `kind: IPPool
+apiVersion: projectcalico.org/v3
+metadata:
+  name: my-ippool
+spec:
+  cidr: 192.168.0.0/16
+  ipipMode: Always
+  vxlanMode: Always
+  natOutgoing: true
+`
+)
+
+var _ = Describe("Create resource from file", func() {
+	It("Should create IPPOOL V6 with Vxlan to Never", func() {
+		resources, err := createResources(IppoolV6WithNeverVxlan)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedIpPools := ipPpols(ipPool("2002::/64", api.VXLANModeNever, api.IPIPModeNever))
+
+		expectResourcesToMatch(resources, expectedIpPools)
+	})
+
+	It("Should create IPPOOL V4 with Vxlan to Always", func() {
+		resources, err := createResources(IppoolV4WithAlwaysVxlan)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedIpPools := ipPpols(ipPool("192.168.0.0/16", api.VXLANModeAlways, api.IPIPModeNever))
+
+		expectResourcesToMatch(resources, expectedIpPools)
+	})
+
+	It("Should create IPPOOL V6 with missing Vxlan to Never", func() {
+		resources, err := createResources(IppoolV6MissingVxlan)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedIpPools := ipPpols(ipPool("2002::/64", api.VXLANModeNever, api.IPIPModeNever))
+
+		expectResourcesToMatch(resources, expectedIpPools)
+	})
+
+	It("Should not create IPPOOL V6 set to Always", func() {
+		_, err := createResources(IppoolV6WithAlwaysVxlan)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should not create IPPOOL V6 when Vxlan is not defined", func() {
+		_, err := createResources(IppoolV6WithErrorVxlan)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should not create IPPOOL V6 when Vxlan and IpIp are both defined", func() {
+		_, err := createResources(IppoolV6WithBothIPIPAndVxlan)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should not create IPPOOL V4 when Vxlan and IpIp are both defined", func() {
+		_, err := createResources(IppoolV4WithBothIPIPAndVxlan)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+func expectResourcesToMatch(resources []runtime.Object, expectedIpPools []*api.IPPool) {
+	Expect(len(expectedIpPools)).To(Equal(len(resources)))
+	for index := range expectedIpPools {
+		Expect(resources[index].DeepCopyObject()).To(Equal(expectedIpPools[index]))
+	}
+}
+
+func ipPool(cidr string, vxlanMode api.VXLANMode, ipipMode api.IPIPMode) *api.IPPool {
+	ippool := api.NewIPPool()
+	ippool.Name = "my-ippool"
+	ippool.Spec = api.IPPoolSpec{CIDR: cidr, VXLANMode: vxlanMode, IPIPMode: ipipMode, NATOutgoing: true}
+	return ippool
+}
+
+func ipPpols(elements ...*api.IPPool) []*api.IPPool {
+	return elements
+}
+
+func createResources(spec string) ([]runtime.Object, error) {
+	By("Writing the spec to a temporary location")
+	file := writeSpec(spec)
+	defer os.Remove(file.Name())
+	By(fmt.Sprintf("Creating resources from file %s", file.Name()))
+	return resourcemgr.CreateResourcesFromFile(file.Name())
+}
+
+func writeSpec(spec string) *os.File {
+	file, err := ioutil.TempFile("/tmp", "resource")
+	file.WriteString(spec)
+	Expect(err).NotTo(HaveOccurred())
+	return file
+}

--- a/glide.lock
+++ b/glide.lock
@@ -224,7 +224,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 83931653472db4b38e19a15e01cf932e10bc44ab
+  version: 0bbf3e55dfb188b73e427deaf0b5a66fd870f368
   repo: https://github.com/asincu/libcalico-go.git
   subpackages:
   - lib/apiconfig

--- a/glide.lock
+++ b/glide.lock
@@ -224,7 +224,8 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 97f275dffda5fcbad25248aec09b556173e09e92
+  version: 83931653472db4b38e19a15e01cf932e10bc44ab
+  repo: https://github.com/asincu/libcalico-go.git
   subpackages:
   - lib/apiconfig
   - lib/apis/v1

--- a/glide.lock
+++ b/glide.lock
@@ -149,6 +149,8 @@ imports:
   version: c182affec369e30f25d3eb8cd8a478dee585ae7d
   subpackages:
   - pbutil
+- name: github.com/mcuadros/go-defaults
+  version: e1c978be3307be96ef03a0bd25d719ab50d277e4
 - name: github.com/mcuadros/go-version
   version: 92cdf37c5b7579ebaf7a036da94b40995972088d
 - name: github.com/mitchellh/mapstructure

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,7 +15,8 @@ import:
   - json
 - package: github.com/projectcalico/go-yaml-wrapper
 - package: github.com/projectcalico/libcalico-go
-  version: 97f275dffda5fcbad25248aec09b556173e09e92
+  repo: https://github.com/asincu/libcalico-go.git
+  version: 83931653472db4b38e19a15e01cf932e10bc44ab
   subpackages:
   - lib/apiconfig
   - lib/apis/v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -61,3 +61,4 @@ testImport:
   subpackages:
   - extensions/table
 - package: github.com/onsi/gomega
+- package: github.com/mcuadros/go-defaults

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,7 +16,7 @@ import:
 - package: github.com/projectcalico/go-yaml-wrapper
 - package: github.com/projectcalico/libcalico-go
   repo: https://github.com/asincu/libcalico-go.git
-  version: 83931653472db4b38e19a15e01cf932e10bc44ab
+  version: 0bbf3e55dfb188b73e427deaf0b5a66fd870f368
   subpackages:
   - lib/apiconfig
   - lib/apis/v1


### PR DESCRIPTION
## Description

Validation of resources needs to be done after setting the proper default values. For example, for VXLAN mode this should be `Never` rather than an empty string.

When applying an ip pool policy with IPV6 CIDR and no VXLAN mode selected via `calicoctl apply -f`

```
---
kind: IPPool
apiVersion: projectcalico.org/v3
metadata:
  name: ippool-2
spec:
  cidr: 2002::/64
  ipipMode: Never
  natOutgoing: true
Calicoctl crashes with (VXLANMode other than 'Never' is not supported on an IPv6 IP pool)
```

Related PR: https://github.com/projectcalico/libcalico-go/pull/1084

## Todos
- [ ] Tests
