### PR TITLE
Remove unmarshalling when creating a resource

### DIFF
--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import (
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	client "github.com/projectcalico/libcalico-go/lib/clientv3"
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
-	validator "github.com/projectcalico/libcalico-go/lib/validator/v3"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -427,14 +426,6 @@ func unmarshalSliceOfResources(tml []unstructured.Unstructured, b []byte) ([]run
 
 	if err := yaml.UnmarshalStrict(b, &unpacked); err != nil {
 		return nil, err
-	}
-
-	// Validate the data in the structures.  The validator does not handle slices, so
-	// validate each resource separately.
-	for _, r := range unpacked {
-		if err := validator.Validate(r); err != nil {
-			return nil, err
-		}
 	}
 
 	log.Infof("Unpacked: %+v", unpacked)

--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -403,12 +403,7 @@ func unmarshalResource(tm unstructured.Unstructured, b []byte) ([]runtime.Object
 		return nil, err
 	}
 
-	log.Infof("Type of unpacked data: %v", reflect.TypeOf(unpacked))
-	if err = validator.Validate(unpacked); err != nil {
-		return nil, err
-	}
-
-	log.Infof("Unpacked: %+v", unpacked)
+	log.Infof("Type of unpacked data: %v. Unpacked %+v", reflect.TypeOf(unpacked), unpacked)
 
 	return []runtime.Object{unpacked}, nil
 }

--- a/calicoctl/resourcemgr/resourcemgr_test.go
+++ b/calicoctl/resourcemgr/resourcemgr_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/projectcalico/calicoctl/calicoctl/resourcemgr"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	DefaultIpPoolTemplate = `kind: IPPool
+apiVersion: projectcalico.org/v3
+metadata:
+  name: {{NAME}}
+spec:
+  cidr: {{CIDR}}
+  ipipMode: {{IPIPMODE}}
+  vxlanMode: {{VXLANMODE}}
+  natOutgoing: true
+`
+)
+
+var _ = Describe("Create resource from file", func() {
+	const CidrV6 = "2002::/64"
+	const CidrV4 = "192.168.0.0/16"
+	const PoolName = "my-ippool"
+	const AnotherPoolName = "another-ippool"
+
+	const VxlanModeNever = string(api.VXLANModeNever)
+	const VxlanModeAlways = string(api.VXLANModeAlways)
+	const IpipModeNever = string(api.IPIPModeNever)
+
+	ipPoolV6WithNeverVxlan := ipPoolSpec(DefaultIpPoolTemplate, CidrV6, PoolName, VxlanModeNever, IpipModeNever)
+	anotherIpPoolV6WithNeverVxlan := ipPoolSpec(DefaultIpPoolTemplate, CidrV6, AnotherPoolName, VxlanModeNever, IpipModeNever)
+	ipPoolV4WithAlwaysVxlan := ipPoolSpec(DefaultIpPoolTemplate, CidrV4, PoolName, VxlanModeAlways, IpipModeNever)
+	anotherIpPoolV4WithAlwaysVxlan := ipPoolSpec(DefaultIpPoolTemplate, CidrV4, AnotherPoolName, VxlanModeAlways, IpipModeNever)
+
+	ipPoolV6 := ipPool(CidrV6, PoolName, api.VXLANModeNever)
+	ipPoolV4 := ipPool(CidrV4, PoolName, api.VXLANModeAlways)
+	anotherIpPoolV6 := ipPool(CidrV6, AnotherPoolName, api.VXLANModeNever)
+	anotherIpPoolV4 := ipPool(CidrV4, AnotherPoolName, api.VXLANModeAlways)
+
+	It("Should create IPPOOL V6 with Vxlan to Never", func() {
+		resources, err := createResources(ipPoolV6WithNeverVxlan)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedIpPools := ipPools(ipPoolV6)
+		expectResourcesToMatch(resources, expectedIpPools)
+	})
+
+	It("Should create IPPOOL V4 with Vxlan to Always", func() {
+		resources, err := createResources(ipPoolV4WithAlwaysVxlan)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedIpPools := ipPools(ipPoolV4)
+		expectResourcesToMatch(resources, expectedIpPools)
+	})
+
+	It("Should create 2 IPPOOL V6 with Vxlan to Never", func() {
+		resources, err := createResources(ipPoolV6WithNeverVxlan, anotherIpPoolV6WithNeverVxlan)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedIpPools := ipPools(ipPoolV6, anotherIpPoolV6)
+		expectResourcesToMatch(resources, expectedIpPools)
+	})
+
+	It("Should create 2 IPPOOL V6 - one with Vxlan to Never and one to Always", func() {
+		resources, err := createResources(ipPoolV6WithNeverVxlan, anotherIpPoolV4WithAlwaysVxlan)
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedIpPools := ipPools(ipPoolV6, anotherIpPoolV4)
+		expectResourcesToMatch(resources, expectedIpPools)
+	})
+
+	It("Should create no resources from an empty Spec", func() {
+		resources, err := createResources()
+		Expect(err).NotTo(HaveOccurred())
+		expectResourcesToMatch(resources, []*api.IPPool{})
+	})
+
+})
+
+func expectResourcesToMatch(resources []runtime.Object, expectedIpPools []*api.IPPool) {
+	Expect(len(expectedIpPools)).To(Equal(len(resources)))
+	for index := range expectedIpPools {
+		Expect(resources[index].DeepCopyObject()).To(Equal(expectedIpPools[index]))
+	}
+}
+
+func ipPoolSpec(ipPoolSpec string, cidr string, name string, vxlanMode string, ipIpMode string) string {
+	macros := map[string]string{
+		"{{NAME}}":      name,
+		"{{CIDR}}":      cidr,
+		"{{VXLANMODE}}": vxlanMode,
+		"{{IPIPMODE}}":  ipIpMode,
+	}
+
+	return replace(macros, ipPoolSpec)
+}
+
+func ipPoolSpecMissingVxlan(ipPoolSpec string, cidr string, name string, ipIpMode string) string {
+	macros := map[string]string{
+		"{{NAME}}":     name,
+		"{{CIDR}}":     cidr,
+		"{{IPIPMODE}}": ipIpMode,
+	}
+
+	return replace(macros, ipPoolSpec)
+}
+
+func ipPoolSpecMissingIpIp(ipPoolSpec string, cidr string, name string) string {
+	macros := map[string]string{
+		"{{NAME}}": name,
+		"{{CIDR}}": cidr,
+	}
+
+	return replace(macros, ipPoolSpec)
+}
+
+func replace(macros map[string]string, spec string) string {
+	for macro, replacement := range macros {
+		spec = strings.Replace(spec, macro, replacement, 1)
+	}
+	return spec
+}
+
+func ipPool(cidr string, name string, vxlanMode api.VXLANMode) *api.IPPool {
+	ipPool := api.NewIPPool()
+	ipPool.Name = name
+	ipPool.Spec = api.IPPoolSpec{CIDR: cidr, VXLANMode: vxlanMode, IPIPMode: api.IPIPModeNever, NATOutgoing: true}
+	return ipPool
+}
+
+func ipPools(elements ...*api.IPPool) []*api.IPPool {
+	return elements
+}
+
+func createResources(specs ...string) ([]runtime.Object, error) {
+	By("Writing specs to a temporary location")
+	content := strings.Join(specs, "\n---\n")
+	file := writeSpec(content)
+	By(fmt.Sprintf("Specs that will be used are: %s", content))
+	defer os.Remove(file.Name())
+	By(fmt.Sprintf("Creating resources from file %s", file.Name()))
+	return resourcemgr.CreateResourcesFromFile(file.Name())
+}
+
+func writeSpec(spec string) *os.File {
+	file, err := ioutil.TempFile("/tmp", "resource")
+	file.WriteString(spec)
+	Expect(err).NotTo(HaveOccurred())
+	return file
+}

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -2088,63 +2088,75 @@ class InvalidData(TestBase):
                                         'source': {}}],
                        }
                    }, "error with field Code = '256'"),
-                   ("compound-config", [{
-                       'apiVersion': API_VERSION,
-                       'kind': 'BGPPeer',
-                       'metadata': {
-                           'name': "compound-config",
-                       },
-                       'spec': {
-                           'node': 'node1',
-                           'peerIP': '192.168.0.250',
-                           'asNumber': 64513
-                       }
-                   },
-                   {
-                       'apiVersion': API_VERSION,
-                       'kind': 'Profile',
-                       'metadata': {
-                           'name': 'profile2',
-                       },
-                       'spec': {
-                           'Egress': [{'action': 'Allow',
-                                       'destination': {},
-                                       'source': {}}],
-                           'Ingress': [{'ipVersion': 4,
-                                        'ICMP': {'type': 256,  # 1-byte field
-                                                 'code': 255},
-                                        'action': 'Deny',
-                                        'protocol': 'ICMP',
-                                        'destination': {},
-                                        'source': {}}],
-                           },
-                   }], "error with field Type = '256'"),
                ]
+
+    compound_test_data = [("compound-config", [{
+        'apiVersion': API_VERSION,
+        'kind': 'BGPPeer',
+        'metadata': {
+            'name': "compound-config",
+        },
+        'spec': {
+            'node': 'node1',
+            'peerIP': '192.168.0.250',
+            'asNumber': 64513
+        }
+    },
+        {
+            'apiVersion': API_VERSION,
+            'kind': 'Profile',
+            'metadata': {
+                'name': 'profile2',
+            },
+            'spec': {
+                'Egress': [{'action': 'Allow',
+                            'destination': {},
+                            'source': {}}],
+                'Ingress': [{'ipVersion': 4,
+                             'ICMP': {'type': 256,  # 1-byte field
+                                      'code': 255},
+                             'action': 'Deny',
+                             'protocol': 'ICMP',
+                             'destination': {},
+                             'source': {}}],
+            },
+        }],{"profile2": "error with field Type = '256'"})]
+
+    def check_no_data_in_store(self, testdata):
+        out = calicoctl("get %s --output=yaml" % testdata['kind'])
+        out.assert_output_contains(
+        'apiVersion: %s\n'
+        'items: []\n'
+        'kind: %sList\n'
+        'metadata:\n'
+        '  resourceVersion: ' % (API_VERSION, testdata['kind'])
+    )
+
 
     @parameterized.expand(testdata)
     def test_invalid_profiles_rejected(self, name, testdata, error):
 
-        def check_no_data_in_store(testdata):
-            out = calicoctl("get %s --output=yaml" % testdata['kind'])
-            out.assert_output_contains(
-                'apiVersion: %s\n'
-                'items: []\n'
-                'kind: %sList\n'
-                'metadata:\n'
-                '  resourceVersion: ' % (API_VERSION, testdata['kind'])
-            )
+        log_and_run("cat << EOF > %s\n%s" % ("/tmp/testfile.yaml", testdata))
+        ctl = calicoctl("create", testdata)
+
+        self.check_no_data_in_store(testdata)
+
+        # Assert that we saw the correct error being reported
+        ctl.assert_error(error)
+
+    @parameterized.expand(compound_test_data)
+    def test_invalid_compound_profiles_rejected(self, name, testdata, errors):
 
         log_and_run("cat << EOF > %s\n%s" % ("/tmp/testfile.yaml", testdata))
         ctl = calicoctl("create", testdata)
 
-        if name.startswith('compound'):
-            for data in testdata:
-                check_no_data_in_store(data)
-        else:
-            check_no_data_in_store(testdata)
+        for data in testdata:
+            if data['metadata']['name'] in errors:
+                self.check_no_data_in_store(data)
 
         # Assert that we saw the correct error being reported
-        ctl.assert_error(error)
+        for value in errors.values():
+            ctl.assert_error(value)
 
 # TODO: uncomment this once we have default field handling in libcalico
 # class TestTypes(TestBase):

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -1986,8 +1986,8 @@ class InvalidData(TestBase):
                        'metadata': {'name': 'pool-invalid-net-1'},
                        'spec': {
                            'ipipMode': 'Always',
-                           'cidr': "10.0.250.0"}  # no mask
-                   }, "error with field IPpool.CIDR = '10.0.250.0/32' "
+                           'cidr': "10.0.250.0/32"}  # no mask
+                   }, "error with field IPPool.Spec.CIDR = '10.0.250.0/32' "
                       "(IP pool size is too small for use with Calico IPAM. It must be equal to or greater than the block size.)"),
                    ("pool-invalidNet4", {
                        'apiVersion': API_VERSION,
@@ -2016,7 +2016,7 @@ class InvalidData(TestBase):
                            'cidr': "::/128",
                        }
                        # nothing
-                   }, "error with field IPpool.CIDR = '::/128' "
+                   }, "error with field IPPool.Spec.CIDR = '::/128' "
                       "(IP pool size is too small for use with Calico IPAM. It must be equal to or greater than the block size.)"),
                    ("pool-invalidNet7", {
                        'apiVersion': API_VERSION,
@@ -2024,7 +2024,7 @@ class InvalidData(TestBase):
                        'metadata': {'name': 'invalid-net-7'},
                        'spec': {
                            'cidr': "192.168.0.0/27"}  # invalid mask
-                   }, "error with field IPpool.CIDR = '192.168.0.0/27' "
+                   }, "error with field IPPool.Spec.CIDR = '192.168.0.0/27' "
                       "(IP pool size is too small for use with Calico IPAM. It must be equal to or greater than the block size.)"),
                    ("pool-invalidNet8", {
                        'apiVersion': API_VERSION,
@@ -2034,7 +2034,7 @@ class InvalidData(TestBase):
                            'ipipMode': 'Never',
                            'cidr': "fd5f::1/123",
                        }  # invalid mask
-                   }, "CIDR = 'fd5f::1/123'"),
+                   }, "IPPool.Spec.CIDR = 'fd5f::/123'"),
                    ("pool-invalidIpIp1", {
                        'apiVersion': API_VERSION,
                        'kind': 'IPPool',


### PR DESCRIPTION
## Description
Remove validation when unmarshalling a resource. The validation will be handled by lib calico, when calling create or update. Libcalico will also set the defaults for missing fields in the process of update/create.

Validation of resources needs to be done after setting the proper default values. For example, for VXLAN mode this should be Never rather than an empty string.

For example, when applying an ip pool policy with IPV6 CIDR and no VXLAN mode selected via calicoctl apply -f
```
---
kind: IPPool
apiVersion: projectcalico.org/v3
metadata:
  name: ippool-2
spec:
  cidr: 2002::/64
  ipipMode: Never
  natOutgoing: true

```
Calicoctl crashes with (VXLANMode other than 'Never' is not supported on an IPv6 IP pool)

## Todos
- [x] Update lib-calico version
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Set resource defaults before performing validation in calicoctl. Note: when creating multiple resources from a single file, calicoctl will now successfully create all valid resources up to the first invalid one before exiting with an error.  
```
