### PR TITLE
calicoctl node run: Plumb in $ETCD_DISCOVERY_SRV

### DIFF
--- a/calicoctl/commands/node/run.go
+++ b/calicoctl/commands/node/run.go
@@ -310,6 +310,7 @@ Description:
 	}
 
 	envs["ETCD_ENDPOINTS"] = etcdcfg.EtcdEndpoints
+	envs["ETCD_DISCOVERY_SRV"] = etcdcfg.EtcdDiscoverySrv
 	if etcdcfg.EtcdCACertFile != "" {
 		envs["ETCD_CA_CERT_FILE"] = ETCD_CA_CERT_NODE_FILE
 		vols = append(vols, vol{hostPath: etcdcfg.EtcdCACertFile, containerPath: ETCD_CA_CERT_NODE_FILE})


### PR DESCRIPTION
## Description

Support the `etcdDiscoverySrv`/`$ETCD_DISCOVERY_SRV` option added to the configuration in https://github.com/projectcalico/libcalico-go/pull/1086/

## Todos
- [ ] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
None required
```
