### PR TITLE
Fix showing IPS IN USE from a large pool as 0

### DIFF
--- a/calicoctl/commands/ipam/show.go
+++ b/calicoctl/commands/ipam/show.go
@@ -97,7 +97,7 @@ Description:
 	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"GROUPING", "CIDR", "IPS TOTAL", "IPS IN USE", "IPS FREE"})
-	genRow := func(kind, cidr string, available, capacity float64) []string {
+	genRow := func(kind, cidr string, inUse, capacity float64) []string {
 		return []string{
 			kind,
 			cidr,
@@ -105,15 +105,15 @@ Description:
 			// Note: the '+capacity/2' bits here give us rounding to the nearest
 			// integer, instead of rounding down, and so ensure that the two percentages
 			// add up to 100.
-			fmt.Sprintf("%.5g (%.f%%)", capacity-available, 100*(capacity-available)/capacity),
-			fmt.Sprintf("%.5g (%.f%%)", available, 100*available/capacity),
+			fmt.Sprintf("%.5g (%.f%%)", inUse, 100*inUse/capacity),
+			fmt.Sprintf("%.5g (%.f%%)", capacity-inUse, 100*(capacity-inUse)/capacity),
 		}
 	}
 	for _, poolUse := range usage {
 		var blockRows [][]string
 		var poolInUse float64
 		for _, blockUse := range poolUse.Blocks {
-			blockRows = append(blockRows, genRow("Block", blockUse.CIDR.String(), float64(blockUse.Available), float64(blockUse.Capacity)))
+			blockRows = append(blockRows, genRow("Block", blockUse.CIDR.String(), float64(blockUse.Capacity-blockUse.Available), float64(blockUse.Capacity)))
 			poolInUse += float64(blockUse.Capacity - blockUse.Available)
 		}
 		ones, bits := poolUse.CIDR.Mask.Size()
@@ -121,7 +121,7 @@ Description:
 		if ones > 0 {
 			// Only show the IP Pool row for a real IP Pool and not for the orphaned
 			// block case.
-			table.Append(genRow("IP Pool", poolUse.CIDR.String(), poolCapacity-poolInUse, poolCapacity))
+			table.Append(genRow("IP Pool", poolUse.CIDR.String(), poolInUse, poolCapacity))
 		}
 		if showBlocks {
 			table.AppendBulk(blockRows)

--- a/tests/fv/ipam_test.go
+++ b/tests/fv/ipam_test.go
@@ -151,10 +151,10 @@ func TestIPAM(t *testing.T) {
 	// | IP Pool  | 10.66.0.0/16                              |      65536 | 11 (0%)    | 65525 (100%)      |
 	// | Block    | 10.66.137.224/29                          |          8 | 8 (100%)   | 0 (0%)            |
 	// | Block    | 10.66.137.232/29                          |          8 | 3 (38%)    | 5 (62%)           |
-	// | IP Pool  | fd5f:abcd:64::/48                         | 1.2089e+24 | 0 (0%)     | 1.2089e+24 (100%) |
+	// | IP Pool  | fd5f:abcd:64::/48                         | 1.2089e+24 | 7 (0%)     | 1.2089e+24 (100%) |
 	// | Block    | fd5f:abcd:64:4f2c:ec1b:27b9:1989:77c0/122 |         64 | 7 (11%)    | 57 (89%)          |
 	// +----------+-------------------------------------------+------------+------------+-------------------+
-	out = Calicoctl("ipam", "show", "--show-blocks")
-	Expect(out).To(ContainSubstring("8 (100%)"))
-	Expect(out).To(ContainSubstring("0 (0%)"))
+	outLines := strings.Split(Calicoctl("ipam", "show", "--show-blocks"), "\n")
+	Expect(outLines).To(ContainElement(And(ContainSubstring("Block"), ContainSubstring("10.66"), ContainSubstring("8 (100%)"), ContainSubstring("0 (0%)"))))
+	Expect(outLines).To(ContainElement(And(ContainSubstring("IP Pool"), ContainSubstring("fd5f"), ContainSubstring("7 (0%)"))))
 }


### PR DESCRIPTION
We were calculating `<large float64> - (<large float64> - <IPs in use>)`,
which gives 0 when `<IPs in use>` is small.  Fix that by removing that
calculation (which was unnecessary).

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [x] Documentation - at https://github.com/projectcalico/calico/pull/2639
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
