### PR TITLE
Fix crash in ipam when NewClient fails

### DIFF
--- a/calicoctl/commands/ipam/show.go
+++ b/calicoctl/commands/ipam/show.go
@@ -63,7 +63,7 @@ Description:
 	cf := parsedArgs["--config"].(string)
 	client, err := clientmgr.NewClient(cf)
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
 
 	showBlocks := parsedArgs["--show-blocks"].(bool)

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import copy
+import os
 
 from nose_parameterized import parameterized
 
@@ -38,6 +39,7 @@ class TestCalicoctlCommands(TestBase):
         """
         Test that a basic CRUD flow for pool commands works.
         """
+
         # Create the ipv6 pool using calicoctl, and read it out using an
         # exact get and a list query.
         rc = calicoctl("create", data=ippool_name2_rev1_v6)
@@ -75,6 +77,32 @@ class TestCalicoctlCommands(TestBase):
         # Assert that deleting the pool again fails.
         rc = calicoctl("delete ippool %s" % name(ippool_name2_rev1_v6))
         rc.assert_error(text=NOT_FOUND)
+
+    def test_no_config(self):
+        """
+        Test that broken store configuration does not crash
+        """
+
+        rc = calicoctl("get policy", no_config=True)
+        rc.assert_error()
+
+        rc = calicoctl("get policy x", no_config=True)
+        rc.assert_error()
+
+        rc = calicoctl("create", data=ippool_name2_rev1_v6, no_config=True)
+        rc.assert_error()
+
+        rc = calicoctl("apply", data=bgppeer_name1_rev2_v4, no_config=True)
+        rc.assert_error()
+
+        rc = calicoctl("replace", data=networkpolicy_name1_rev2, no_config=True)
+        rc.assert_error()
+
+        rc = calicoctl("label workloadendpoint node1-k8s-abcd-eth0 app=web --namespace=namespace1", no_config=True)
+        rc.assert_error()
+
+        rc = calicoctl("ipam show", no_config=True)
+        rc.assert_error()
 
     def test_get_delete_multiple_names(self):
         """


### PR DESCRIPTION
Does not panic

Adds assert_output_not_contains in test infra

fixes OS-4514

## Description

Adds some testing about broken store configuration. However, those tests take ~10s to timeout and fail.


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
