### PR TITLE
Fix erroneous "Partial success" output

### DIFF
--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -99,28 +99,30 @@ Description:
 		if results.numResources == 0 {
 			return fmt.Errorf("No resources specified in file")
 		} else if results.numResources == 1 {
-			return fmt.Errorf("Failed to apply '%s' resource: %v", results.singleKind, results.err)
+			return fmt.Errorf("Failed to apply '%s' resource: %v", results.singleKind, results.resErrs)
 		} else if results.singleKind != "" {
-			return fmt.Errorf("Failed to apply any '%s' resources: %v", results.singleKind, results.err)
+			return fmt.Errorf("Failed to apply any '%s' resources: %v", results.singleKind, results.resErrs)
 		} else {
-			return fmt.Errorf("Failed to apply any resources: %v", results.err)
+			return fmt.Errorf("Failed to apply any resources: %v", results.resErrs)
 		}
-	} else if results.err == nil {
+	} else if len(results.resErrs) == 0 {
 		if results.singleKind != "" {
 			fmt.Printf("Successfully applied %d '%s' resource(s)\n", results.numHandled, results.singleKind)
 		} else {
 			fmt.Printf("Successfully applied %d resource(s)\n", results.numHandled)
 		}
 	} else {
-		fmt.Printf("Partial success: ")
-		if results.singleKind != "" {
-			fmt.Printf("applied the first %d out of %d '%s' resources:\n",
-				results.numHandled, results.numResources, results.singleKind)
-		} else {
-			fmt.Printf("applied the first %d out of %d resources:\n",
-				results.numHandled, results.numResources)
+		if results.numHandled - len(results.resErrs) > 0 {
+			fmt.Printf("Partial success: ")
+			if results.singleKind != "" {
+				fmt.Printf("applied the first %d out of %d '%s' resources:\n",
+					results.numHandled, results.numResources, results.singleKind)
+			} else {
+				fmt.Printf("applied the first %d out of %d resources:\n",
+					results.numHandled, results.numResources)
+			}
 		}
-		return fmt.Errorf("Hit error: %v", results.err)
+		return fmt.Errorf("Hit error(s): %v", results.resErrs)
 	}
 
 	return nil

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -96,28 +96,30 @@ Description:
 		if results.numResources == 0 {
 			return fmt.Errorf("No resources specified in file")
 		} else if results.numResources == 1 {
-			return fmt.Errorf("Failed to create '%s' resource: %v", results.singleKind, results.err)
+			return fmt.Errorf("Failed to create '%s' resource: %v", results.singleKind, results.resErrs)
 		} else if results.singleKind != "" {
-			return fmt.Errorf("Failed to create any '%s' resources: %v", results.singleKind, results.err)
+			return fmt.Errorf("Failed to create any '%s' resources: %v", results.singleKind, results.resErrs)
 		} else {
-			return fmt.Errorf("Failed to create any resources: %v", results.err)
+			return fmt.Errorf("Failed to create any resources: %v", results.resErrs)
 		}
-	} else if results.err == nil {
+	} else if len(results.resErrs) == 0 {
 		if results.singleKind != "" {
 			fmt.Printf("Successfully created %d '%s' resource(s)\n", results.numHandled, results.singleKind)
 		} else {
 			fmt.Printf("Successfully created %d resource(s)\n", results.numHandled)
 		}
 	} else {
-		fmt.Printf("Partial success: ")
-		if results.singleKind != "" {
-			fmt.Printf("created the first %d out of %d '%s' resources:\n",
-				results.numHandled, results.numResources, results.singleKind)
-		} else {
-			fmt.Printf("created the first %d out of %d resources:\n",
-				results.numHandled, results.numResources)
+		if results.numHandled - len(results.resErrs) > 0 {
+			fmt.Printf("Partial success: ")
+			if results.singleKind != "" {
+				fmt.Printf("created the first %d out of %d '%s' resources:\n",
+					results.numHandled, results.numResources, results.singleKind)
+			} else {
+				fmt.Printf("created the first %d out of %d resources:\n",
+					results.numHandled, results.numResources)
+			}
 		}
-		return fmt.Errorf("Hit error: %v", results.err)
+		return fmt.Errorf("Hit error: %v", results.resErrs)
 	}
 
 	return nil

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -215,7 +215,7 @@ func executeConfigCommand(args map[string]interface{}, action action) commandRes
 		res, err := executeResourceAction(args, client, r, action)
 		if err != nil {
 			switch action {
-			case actionDelete, actionGetOrList:
+			case actionApply, actionDelete, actionGetOrList:
 				results.resErrs = append(results.resErrs, err)
 				continue
 			default:

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -215,7 +215,7 @@ func executeConfigCommand(args map[string]interface{}, action action) commandRes
 		res, err := executeResourceAction(args, client, r, action)
 		if err != nil {
 			switch action {
-			case actionApply, actionDelete, actionGetOrList:
+			case actionApply, actionCreate, actionDelete, actionGetOrList:
 				results.resErrs = append(results.resErrs, err)
 				continue
 			default:

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -279,6 +279,24 @@ class TestCalicoctlCommands(TestBase):
         rc = calicoctl("replace", data=networkpolicy_name1_rev2)
         rc.assert_error(text=NOT_FOUND)
 
+    def test_create_single_invalid_resource(self):
+        """
+        Test that creating a single invalid resource returns an appropriate error
+        """
+        rc = calicoctl("create", data=bgppeer_invalid, format="json")
+        rc.assert_error(text="error with field PeerIP = 'badpeerIP'")
+        rc.assert_output_not_contains("Partial success")
+        rc.assert_output_contains("Failed to create 'BGPPeer' resource")
+
+    def test_create_all_invalid_resources(self):
+        """
+        Test that creating multiple invalid resources returns an appropriate error
+        """
+        rc = calicoctl("create", data=bgppeer_multiple_invalid, format="json")
+        rc.assert_error(text="error with field PeerIP = 'badpeerIP'")
+        rc.assert_output_not_contains("Partial success")
+        rc.assert_output_contains("Failed to create any 'BGPPeer' resources")
+
     def test_apply_single_invalid_resource(self):
         """
         Test that applying a single invalid resource returns an appropriate error

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -279,6 +279,24 @@ class TestCalicoctlCommands(TestBase):
         rc = calicoctl("replace", data=networkpolicy_name1_rev2)
         rc.assert_error(text=NOT_FOUND)
 
+    def test_apply_single_invalid_resource(self):
+        """
+        Test that applying a single invalid resource returns an appropriate error
+        """
+        rc = calicoctl("apply", data=bgppeer_invalid)
+        rc.assert_error(text="error with field PeerIP = 'badpeerIP'")
+        rc.assert_output_not_contains("Partial success")
+        rc.assert_output_contains("Failed to apply 'BGPPeer' resource")
+
+    def test_apply_all_invalid_resources(self):
+        """
+        Test that applying multiple invalid resources returns an appropriate error
+        """
+        rc = calicoctl("apply", data=bgppeer_multiple_invalid)
+        rc.assert_error(text="error with field PeerIP = 'badpeerIP'")
+        rc.assert_output_not_contains("Partial success")
+        rc.assert_output_contains("Failed to apply any 'BGPPeer' resources")
+
     def test_apply_with_resource_version(self):
         """
         Test that resource version operates correctly with apply, i.e.

--- a/tests/st/utils/data.py
+++ b/tests/st/utils/data.py
@@ -133,6 +133,43 @@ bgppeer_name2_rev1_v6 = {
     },
 }
 
+bgppeer_invalid = {
+    'apiVersion': API_VERSION,
+    'kind': 'BGPPeer',
+    'metadata': {
+        'name': 'bgppeer-name-123abc',
+    },
+    'spec':  {
+        'node': 'node2',
+        'peerIP': 'badpeerIP',
+        'asNumber': 64515,
+    },
+}
+
+bgppeer_multiple_invalid = [{
+    'apiVersion': API_VERSION,
+    'kind': 'BGPPeer',
+    'metadata': {
+        'name': 'bgppeer-invalid1',
+    },
+    'spec':  {
+        'node': 'node1',
+        'peerIP': 'badpeerIP',
+        'asNumber': 64515,
+    },
+}, {
+    'apiVersion': API_VERSION,
+    'kind': 'BGPPeer',
+    'metadata': {
+        'name': 'bgppeer-invalid2',
+    },
+    'spec':  {
+        'node': 'node2',
+        'peerIP': 'badpeerIP',
+        'asNumber': 64515,
+    }
+}]
+
 #
 # Network Policy
 #


### PR DESCRIPTION
## Description

This fixes `Partial success` messages being returned to the user when the command failed completely. E.g.:

```
$ calicoctl apply -f - <<EOF
> apiVersion: projectcalico.org/v3
> kind: BGPPeer
> metadata:
>   name: some.name
> spec:
>   node: rack1-host1
>   peerIP: oops
>   asNumber: 63400
> EOF
Partial success: applied the first 1 out of 1 'BGPPeer' resources:
Hit error: error with field PeerIP = 'oops' (Reason: failed to validate Field: PeerIP because of Tag: ip )
command terminated with exit code 1
```

Once this is merged, I'll cherry-pick into release-v3.10
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
