### PR TITLE
node diags: auto remove ipset list container

### DIFF
--- a/calicoctl/commands/node/diags.go
+++ b/calicoctl/commands/node/diags.go
@@ -88,7 +88,7 @@ func runDiags(logDir string) error {
 		{"Dumping iptables (IPv4)", "iptables-save -c", "ipv4_tables"},
 		{"Dumping iptables (IPv6)", "ip6tables-save -c", "ipv6_tables"},
 		{"Dumping ipsets", "ipset list", "ipsets"},
-		{"Dumping ipsets (container)", "docker run --privileged --net=host calico/node ipset list", "ipset_container"},
+		{"Dumping ipsets (container)", "docker run --rm --privileged --net=host calico/node ipset list", "ipset_container"},
 		{"Copying journal for calico-node.service", "journalctl -u calico-node.service --no-pager", "journalctl_calico_node"},
 		{"Dumping felix stats", "pkill -SIGUSR1 felix", ""},
 	}


### PR DESCRIPTION
## Description
Autoremove `calicoctl node diags` "`ipset list`" container, which is currently hanging around as cruft after collecting a diag.

## Todos
- [x] Tests (N/A)
- [x] Documentation (N/A)
- [x] Release note (N/A)

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```