### PR TITLE
node diags: use shorthand for netstat

### DIFF
--- a/calicoctl/commands/node/diags.go
+++ b/calicoctl/commands/node/diags.go
@@ -80,7 +80,7 @@ func runDiags(logDir string) error {
 	cmds := []diagCmd{
 		{"", "date", "date"},
 		{"", "hostname", "hostname"},
-		{"Dumping netstat", "netstat --all --numeric", "netstat"},
+		{"Dumping netstat", "netstat -a -n", "netstat"},
 		{"Dumping routes (IPv4)", "ip -4 route", "ipv4_route"},
 		{"Dumping routes (IPv6)", "ip -6 route", "ipv6_route"},
 		{"Dumping interface info (IPv4)", "ip -4 addr", "ipv4_addr"},


### PR DESCRIPTION
busybox netstat isn't as full featured as the net-tools source and fails to dump on these distros capable of running Kubernetes.

Currently busybox (compile-time define) supports:
```"\n	-r	Routing table"
"\n	-a	All sockets"
"\n	-l	Listening sockets"
"\n		Else: connected sockets"
"\n	-t	TCP sockets"
"\n	-u	UDP sockets"
"\n	-w	Raw sockets"
"\n	-x	Unix sockets"
"\n		Else: all socket types"
"\n	-e	Other/more information"
"\n	-n	Don't resolve names"
IF_FEATURE_NETSTAT_WIDE(
"\n	-W	Wide display"
)
IF_FEATURE_NETSTAT_PRG(
"\n	-p	Show PID/program name for sockets"
)
```

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
