### PR TITLE
Extend Kernel dependecies checker

### DIFF
--- a/calicoctl/commands/node/checksystem.go
+++ b/calicoctl/commands/node/checksystem.go
@@ -33,7 +33,8 @@ import (
 const minKernelVersion = "2.6.24"
 
 // Required kernel modules to run Calico
-var requiredModules = []string{"xt_set", "ip6_tables"}
+var requiredModules = []string{"ip_set", "ip_tables", "ip6_tables", "ipt_REJECT", "ipt_rpfilter", "ipt_set", "nf_conntrack_netlink",
+	"xt_addrtype", "xt_conntrack", "xt_icmp", "xt_icmp6", "xt_ipvs", "xt_mark", "xt_multiport", "xt_rpfilter", "xt_set", "xt_u32"}
 
 // Checksystem checks host system for compatible versions
 func Checksystem(args []string) error {


### PR DESCRIPTION
## Description

There were some missing Kernel dependencies in the list of required modules.

Partly fixes: https://github.com/projectcalico/calicoctl/issues/1444

`ipip` kernel module is still missing, but it is only needed on case of `Calico` networking.

## Todos
- [ ] Tests
- [X] Documentation
- [X] Release note

## Release Note

```release-note
More precise Kernel module dependency checking in calicoctl checksystem
```
