### PR TITLE
Fix building of binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,9 @@ bin/calicoctl-%-s390x: ARCH=s390x
 bin/calicoctl-darwin-amd64: BUILDOS=darwin
 bin/calicoctl-windows-amd64: BUILDOS=windows
 bin/calicoctl-linux-%: BUILDOS=linux
+# We reinvoke make here to re-evaluate BUILDOS and ARCH so the correct values
+# for multi-platform builds are used. When make is initially invoked, BUILDOS
+# and ARCH are defined with default values (Linux and amd64).
 bin/calicoctl-%: $(LOCAL_BUILD_DEP) $(SRC_FILES)
 	$(MAKE) build-calicoctl BUILDOS=$(BUILDOS) ARCH=$(ARCH)
 build-calicoctl:

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,9 @@ update-pins: update-libcalico-pin
 .PHONY: build-all
 ## Build the binaries for all architectures and platforms
 build-all: $(addprefix bin/calicoctl-linux-,$(VALIDARCHES)) bin/calicoctl-windows-amd64.exe bin/calicoctl-darwin-amd64
-
 .PHONY: build
 ## Build the binary for the current architecture and platform
 build: bin/calicoctl-$(BUILDOS)-$(ARCH)
-
 # The supported different binary names. For each, ensure that an OS and ARCH is set
 bin/calicoctl-%-amd64: ARCH=amd64
 bin/calicoctl-%-arm64: ARCH=arm64
@@ -82,15 +80,15 @@ bin/calicoctl-%-s390x: ARCH=s390x
 bin/calicoctl-darwin-amd64: BUILDOS=darwin
 bin/calicoctl-windows-amd64: BUILDOS=windows
 bin/calicoctl-linux-%: BUILDOS=linux
-
 bin/calicoctl-%: $(LOCAL_BUILD_DEP) $(SRC_FILES)
+	$(MAKE) build-calicoctl BUILDOS=$(BUILDOS) ARCH=$(ARCH)
+build-calicoctl:
 	mkdir -p bin
 	$(DOCKER_RUN) \
 	  -e CALICOCTL_GIT_REVISION=$(CALICOCTL_GIT_REVISION) \
 	  -v $(CURDIR)/bin:/go/src/$(PACKAGE_NAME)/bin \
 	  $(CALICO_BUILD) \
 	  go build -v -o bin/calicoctl-$(BUILDOS)-$(ARCH) $(LDFLAGS) "./calicoctl/calicoctl.go"
-
 # Overrides for the binaries that need different output names
 bin/calicoctl: bin/calicoctl-linux-amd64
 	cp $< $@


### PR DESCRIPTION
## Description

Binaries being built with `build-all` are all ELF amd64 binaries:

```
user@ubuntu:~/go/src/github.com/projectcalico/calicoctl/bin$ file *
calicoctl-darwin-amd64:      ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=T3nSzwyun3ZO3NrIgiNC/qpbBPYeZAdbUJ8zwknfr/6L-QOdSFg-AzsZO7DoFT/EBvUJHJ_Fudra53kNuvL, stripped
calicoctl-linux-amd64:       ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=T3nSzwyun3ZO3NrIgiNC/qpbBPYeZAdbUJ8zwknfr/6L-QOdSFg-AzsZO7DoFT/EBvUJHJ_Fudra53kNuvL, stripped
calicoctl-linux-arm64:       ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=T3nSzwyun3ZO3NrIgiNC/qpbBPYeZAdbUJ8zwknfr/6L-QOdSFg-AzsZO7DoFT/EBvUJHJ_Fudra53kNuvL, stripped
calicoctl-linux-ppc64le:     ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=T3nSzwyun3ZO3NrIgiNC/qpbBPYeZAdbUJ8zwknfr/6L-QOdSFg-AzsZO7DoFT/EBvUJHJ_Fudra53kNuvL, stripped
calicoctl-windows-amd64.exe: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=T3nSzwyun3ZO3NrIgiNC/qpbBPYeZAdbUJ8zwknfr/6L-QOdSFg-AzsZO7DoFT/EBvUJHJ_Fudra53kNuvL, stripped
```

With this PR:
```
user@ubuntu:~/go/src/github.com/projectcalico/calicoctl/bin$ file *
calicoctl-darwin-amd64:      Mach-O 64-bit x86_64 executable
calicoctl-linux-amd64:       ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=8I8-jLxIxiV-lIFRh5kz/qpbBPYeZAdbUJ8zwknfr/6L-QOdSFg-AzsZO7DoFT/C5M7wChLzeoz0XuTxy1V, stripped
calicoctl-linux-arm64:       ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=pOG8ViXGifAfuZocenH9/t_BTMIKxqa5eHLK2GSxW/FwSceWNODEkCdOyClUHs/JJpcM4VKXd5rQcw9jNIg, stripped
calicoctl-linux-ppc64le:     ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, Go BuildID=NqtBYGHJZqHY-brpgwpl/eKnFwq1jKE8M7nq-rFWj/OnkAPam9GKfnqZumVBKo/fB17YH_4n5GmqPbAB1w4, stripped
calicoctl-windows-amd64.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
```

This fixes #2091

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ 

this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
