### PR TITLE
calicoctl node diags -A (all nodes - from anywhere).

### DIFF
--- a/calicoctl/commands/node/diags.go
+++ b/calicoctl/commands/node/diags.go
@@ -110,7 +110,7 @@ func runDiags(logDir string) error {
 		return fmt.Errorf("Error changing directory to temp directory to dump logs: %v", err)
 	}
 
-	err = os.Mkdir("diagnostics", os.ModeDir)
+	err = os.Mkdir("diagnostics", os.ModeDir | 0750)
 	if err != nil {
 		return fmt.Errorf("Error creating diagnostics directory: %v\n", err)
 	}


### PR DESCRIPTION
## Description
There's no easy way to grab distributed information from nodes cleanly and in a upload-ready format.
I came up with ```alias calicopods="kubectl get pod -l 'k8s-app=calico-node' -n calico-system -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | xargs -I{} kubectl exec -n calico-system {} -- bash -c "``` but it's not ideal.

Usage:
```calicopods 'hostname && date && uname -a && printf "%0.s-" {1..90} && echo'
calicopods 'hostname && date && cat /etc/*release || cat /etc/*version && printf "%0.s-" {1..90} && echo'
calicopods 'hostname && date && dmesg && printf "%0.s-" {1..90} && echo'
calicopods 'hostname && date && netstat -a -n && printf "%0.s-" {1..90} && echo'
``` 
This still results in a bit of pain to get into individual files, and with 300+ node environments is not ideal.

This replaces https://github.com/projectcalico/calicoctl/pull/2083 as we're leveraging the tools present from calico-node - which is a more full-featured installation than our traditional k8s node OS. The current implementation also uses go routines and completes in seconds: the current (rough) limit is 70,000 nodes.

The existing behaviour should be preserved - but will quit later due to the id=0 requirement we presently have.