### PR TITLE
add comment for using ST_TO_RUN variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,8 @@ fv: $(LOCAL_BUILD_DEP) bin/calicoctl-linux-amd64
 # STs
 ###############################################################################
 LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 | awk '{print $$7}')
+# To run a specific test, set ST_TO_RUN to testfile.py:class.method
+# e.g. ST_TO_RUN="tests/st/calicoctl/test_crud.py:TestCalicoctlCommands.test_get_delete_multiple_names"
 ST_TO_RUN?=tests/st/calicoctl/
 # Can exclude the slower tests with "-a '!slow'"
 ST_OPTIONS?=


### PR DESCRIPTION
## Description
Maybe just me (but I doubt it), I always forget how `nosetest` wants a specific test to run, versus `pytest`.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
