### PR TITLE
Operator: Update calicoctl to ubi as base image

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,7 +1,32 @@
-FROM amd64/alpine:3.10
-MAINTAINER Tom Denham <tom@projectcalico.org>
+# Copyright (c) 2020 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+ARG GIT_VERSION=unknown
+
+LABEL name="Calico CLI tool" \
+      vendor="Project Calico" \
+      version=$GIT_VERSION \
+      release="1" \
+      summary="Calico CLI tool" \
+      description="calicoctl(1) is a command line tool used to interface with the Calico datastore " \
+      maintainer="maintainers@projectcalico.org"
 
 ADD bin/calicoctl-linux-amd64 /calicoctl
+
+RUN mkdir /licenses
+COPY LICENSE /licenses
 
 ENV CALICO_CTL_CONTAINER=TRUE
 ENV PATH=$PATH:/

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ bin/calicoctl-windows-amd64.exe: bin/calicoctl-windows-amd64
 image: $(BUILD_IMAGE)
 $(BUILD_IMAGE): $(CTL_CONTAINER_CREATED)
 $(CTL_CONTAINER_CREATED): Dockerfile.$(ARCH) bin/calicoctl-linux-$(ARCH)
-	docker build -t $(BUILD_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) -f Dockerfile.$(ARCH) .
+	docker build -t $(BUILD_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
 ifeq ($(ARCH),amd64)
 	docker tag $(BUILD_IMAGE):latest-$(ARCH) $(BUILD_IMAGE):latest
 endif


### PR DESCRIPTION
```release-note
The calicoctl image is now using registry.access.redhat.com/ubi8/ubi-minimal:8.1 instead of Alpine for the base image.
```
