### PR TITLE
Fix CVEs, use scratch based Image

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2 as ubi
+
+RUN mkdir /licenses
+COPY LICENSE /licenses
+
+FROM scratch
 ARG GIT_VERSION=unknown
 
 LABEL name="Calico CLI tool" \
@@ -23,10 +28,9 @@ LABEL name="Calico CLI tool" \
       description="calicoctl(1) is a command line tool used to interface with the Calico datastore " \
       maintainer="maintainers@projectcalico.org"
 
+COPY --from=ubi /licenses /licenses
 ADD bin/calicoctl-linux-amd64 /calicoctl
-
-RUN mkdir /licenses
-COPY LICENSE /licenses
+ADD bin/calicoctl-wait-linux-amd64 /calicoctl-wait
 
 ENV CALICO_CTL_CONTAINER=TRUE
 ENV PATH=$PATH:/

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,8 @@ bin/calicoctl-linux-%: BUILDOS=linux
 # and ARCH are defined with default values (Linux and amd64).
 bin/calicoctl-%: $(LOCAL_BUILD_DEP) $(SRC_FILES)
 	$(MAKE) build-calicoctl BUILDOS=$(BUILDOS) ARCH=$(ARCH)
+bin/calicoctl-wait-%: $(LOCAL_BUILD_DEP) $(SRC_FILES)
+	$(MAKE) build-calicoctl-wait BUILDOS=$(BUILDOS) ARCH=$(ARCH)
 build-calicoctl:
 	mkdir -p bin
 	$(DOCKER_RUN) \
@@ -92,8 +94,15 @@ build-calicoctl:
 	  -v $(CURDIR)/bin:/go/src/$(PACKAGE_NAME)/bin \
 	  $(CALICO_BUILD) \
 	  go build -v -o bin/calicoctl-$(BUILDOS)-$(ARCH) $(LDFLAGS) "./calicoctl/calicoctl.go"
+build-calicoctl-wait:
+	$(DOCKER_RUN) $(EXTRA_DOCKER_ARGS) \
+	  -e CALICOCTL_GIT_REVISION=$(CALICOCTL_GIT_REVISION) \
+	  -v $(CURDIR)/bin:/go/src/$(PACKAGE_NAME)/bin \
+	  $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) go build -v -o bin/calicoctl-wait-$(BUILDOS)-$(ARCH) $(LDFLAGS) "./calicoctl-wait/calicoctl-wait.go"'
 # Overrides for the binaries that need different output names
 bin/calicoctl: bin/calicoctl-linux-amd64
+	cp $< $@
+bin/calicoctl-wait: bin/calicoctl-linux-amd64
 	cp $< $@
 bin/calicoctl-windows-amd64.exe: bin/calicoctl-windows-amd64
 	mv $< $@
@@ -116,7 +125,7 @@ remote-deps: mod-download
 .PHONY: image $(BUILD_IMAGE)
 image: $(BUILD_IMAGE)
 $(BUILD_IMAGE): $(CTL_CONTAINER_CREATED)
-$(CTL_CONTAINER_CREATED): Dockerfile.$(ARCH) bin/calicoctl-linux-$(ARCH)
+$(CTL_CONTAINER_CREATED): Dockerfile.$(ARCH) bin/calicoctl-linux-$(ARCH) bin/calicoctl-wait-linux-$(ARCH)
 	docker build -t $(BUILD_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
 ifeq ($(ARCH),amd64)
 	docker tag $(BUILD_IMAGE):latest-$(ARCH) $(BUILD_IMAGE):latest

--- a/calicoctl-wait/calicoctl-wait.go
+++ b/calicoctl-wait/calicoctl-wait.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"time"
+)
+
+func main() {
+	// Spin continously in tight loop
+	for {
+		time.Sleep(500 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Description
Build scratch based Image, with only statically built applications[calicoctl & calicoctl-wait]
1) Built small application to wait for in an indefinite loop.
