### PR TITLE
Fix issue making gen-crds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ GO_BUILD_VER=v0.40
 #   Additions to EXTRA_DOCKER_ARGS need to happen before the include since
 #   that variable is evaluated when we declare DOCKER_RUN and siblings.
 ###############################################################################
+EXTRA_DOCKER_ARGS+=-v $(CURDIR)/../libcalico-go:/go/src/github.com/projectcalico/libcalico-go:rw
+
 MAKE_BRANCH?=$(GO_BUILD_VER)
 MAKE_REPO?=https://raw.githubusercontent.com/projectcalico/go-build/$(MAKE_BRANCH)
 
@@ -22,7 +24,6 @@ ifdef LOCAL_BUILD
 PHONY: set-up-local-build
 LOCAL_BUILD_DEP:=set-up-local-build
 
-EXTRA_DOCKER_ARGS+=-v $(CURDIR)/../libcalico-go:/go/src/github.com/projectcalico/libcalico-go:rw
 $(LOCAL_BUILD_DEP):
 	$(DOCKER_RUN) $(CALICO_BUILD) go mod edit -replace=github.com/projectcalico/libcalico-go=../libcalico-go
 endif


### PR DESCRIPTION
## Description
Running `make gen-crds` was failing.  Tracked issue down to EXTRA_DOCKER_ARGS needing to be declared before including Makefile.common.

## Todos
Now that `make gen-crds` works, it highlights the issue that `commands/crds/crds.go` is out of date.

## Release Note
```release-note
None required
```
