### PR TITLE
Fix import from libcalico-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ gen-crds: remote-deps
 remote-deps: mod-download	
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -ec ' \
 		$(GIT_CONFIG_SSH) \
-		cp -r `go list -m -f "{{.Dir}}" github.com/projectcalico/libcalico-go`/config config; \
+		cp -r `go list -m -f "{{.Dir}}" github.com/projectcalico/libcalico-go`/config .; \
 		chmod -R +w config/'
 
 ###############################################################################


### PR DESCRIPTION
## Description
When running `make gen-crds` the first time, files are copied into `calicoctl/config/crd/...`

However, when running `make gen-crds` a second time without deleting the `config` directory, files are copied into `calicoctl/config/config/crd/...`.  This means that any updates to libcalico-go will not be reflected in `crds.go`.  As a case in point, the current release is missing some updates, see PR #2151.

Also note that the config directory is not deleted when `make clean` is run, that may want to be addressed as well.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
