### PR TITLE
Add ability to specify directory as filename parameter

### DIFF
--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -29,14 +29,14 @@ func main() {
 	doc := `Usage:
   calicoctl [options] <command> [<args>...]
 
-    create       Create a resource by filename or stdin.
-    replace      Replace a resource by filename or stdin.
-    apply        Apply a resource by filename or stdin.  This creates a resource
+    create       Create a resource by file, directory or stdin.
+    replace      Replace a resource by file, directory or stdin.
+    apply        Apply a resource by file, directory or stdin.  This creates a resource
                  if it does not exist, and replaces a resource if it does exists.
     patch        Patch a pre-exisiting resource in place.
-    delete       Delete a resource identified by file, stdin or resource type and
+    delete       Delete a resource identified by file, directory, stdin or resource type and
                  name.
-    get          Get a resource identified by file, stdin or resource type and
+    get          Get a resource identified by file, directory, stdin or resource type and
                  name.
     label        Add or update labels of resources.
     convert      Convert config files between different API versions.

--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -20,8 +20,9 @@ import (
 	"strings"
 
 	"github.com/docopt/docopt-go"
-	"github.com/projectcalico/calicoctl/calicoctl/commands"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/calicoctl/calicoctl/commands"
 )
 
 func main() {

--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2020 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 
 func Apply(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl apply --filename=<FILENAME> [--config=<CONFIG>] [--namespace=<NS>]
+  calicoctl apply --filename=<FILENAME> [--recursive] [--config=<CONFIG>] [--namespace=<NS>]
 
 Examples:
   # Apply a policy using the data in policy.yaml.
@@ -39,7 +39,10 @@ Examples:
 Options:
   -h --help                 Show this screen.
   -f --filename=<FILENAME>  Filename to use to apply the resource.  If set to
-                            "-" loads from stdin.
+                            "-" loads from stdin. If filename is a directory, this command is
+                            invoked for each .json .yaml and .yml file within that directory,
+                            terminating after the first failure.
+  -R --recursive            Process the filename specified in -f or --filename recursively.
   -c --config=<CONFIG>      Path to the file containing connection
                             configuration in YAML or JSON format.
                             [default: ` + constants.DefaultConfigPath + `]

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -27,7 +27,8 @@ import (
 
 func Create(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl create --filename=<FILENAME> [--recursive] [--skip-exists] [--config=<CONFIG>] [--namespace=<NS>]
+  calicoctl create --filename=<FILENAME> [--recursive] [--skip-empty]
+                   [--skip-exists] [--config=<CONFIG>] [--namespace=<NS>]
 
 Examples:
   # Create a policy using the data in policy.yaml.
@@ -43,6 +44,8 @@ Options:
                             invoked for each .json .yaml and .yml file within that directory,
                             terminating after the first failure.
   -R --recursive            Process the filename specified in -f or --filename recursively.
+     --skip-empty           Do not error if any files or directory specified using -f or --filename contain no
+                            data.
      --skip-exists          Skip over and treat as successful any attempts to
                             create an entry that already exists.
   -c --config=<CONFIG>      Path to the file containing connection
@@ -97,10 +100,14 @@ Description:
 
 	if results.FileInvalid {
 		return fmt.Errorf("Failed to execute command: %v", results.Err)
+	} else if results.NumResources == 0 {
+		// No resources specified. If there is an associated error use that, otherwise print message with no error.
+		if results.Err != nil {
+			return results.Err
+		}
+		fmt.Println("No resources specified")
 	} else if results.NumHandled == 0 {
-		if results.NumResources == 0 {
-			return fmt.Errorf("No resources specified in file")
-		} else if results.NumResources == 1 {
+		if results.NumResources == 1 {
 			return fmt.Errorf("Failed to create '%s' resource: %v", results.SingleKind, results.ResErrs)
 		} else if results.SingleKind != "" {
 			return fmt.Errorf("Failed to create any '%s' resources: %v", results.SingleKind, results.ResErrs)

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -27,7 +27,7 @@ import (
 
 func Create(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl create --filename=<FILENAME> [--skip-exists] [--config=<CONFIG>] [--namespace=<NS>]
+  calicoctl create --filename=<FILENAME> [--recursive] [--skip-exists] [--config=<CONFIG>] [--namespace=<NS>]
 
 Examples:
   # Create a policy using the data in policy.yaml.
@@ -39,7 +39,10 @@ Examples:
 Options:
   -h --help                 Show this screen.
   -f --filename=<FILENAME>  Filename to use to create the resource.  If set to
-                            "-" loads from stdin.
+                            "-" loads from stdin. If filename is a directory, this command is
+                            invoked for each .json .yaml and .yml file within that directory,
+                            terminating after the first failure.
+  -R --recursive            Process the filename specified in -f or --filename recursively.
      --skip-exists          Skip over and treat as successful any attempts to
                             create an entry that already exists.
   -c --config=<CONFIG>      Path to the file containing connection

--- a/calicoctl/commands/datastore.go
+++ b/calicoctl/commands/datastore.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/docopt/docopt-go"
+
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/datastore"
 )

--- a/calicoctl/commands/datastore/migrate.go
+++ b/calicoctl/commands/datastore/migrate.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/docopt/docopt-go"
+
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/datastore/migrate"
 )

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -28,7 +28,7 @@ import (
 func Delete(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl delete ( (<KIND> [<NAME>...]) |
-                   --filename=<FILE>)
+                   --filename=<FILE> [--recursive])
                    [--skip-not-exists] [--config=<CONFIG>] [--namespace=<NS>]
 
 Examples:
@@ -46,7 +46,10 @@ Options:
   -s --skip-not-exists      Skip over and treat as successful, resources that
                             don't exist.
   -f --filename=<FILENAME>  Filename to use to delete the resource.  If set to
-                            "-" loads from stdin.
+                            "-" loads from stdin. If filename is a directory, this command is
+                            invoked for each .json .yaml and .yml file within that directory,
+                            terminating after the first failure.
+  -R --recursive            Process the filename specified in -f or --filename recursively.
   -c --config=<CONFIG>      Path to the file containing connection
                             configuration in YAML or JSON format.
                             [default: ` + constants.DefaultConfigPath + `]

--- a/calicoctl/commands/file/file_suite_test.go
+++ b/calicoctl/commands/file/file_suite_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	"github.com/onsi/ginkgo/reporters"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+}
+
+func TestCommands(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../../report/file_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "File Suite", []Reporter{junitReporter})
+}

--- a/calicoctl/commands/file/iter.go
+++ b/calicoctl/commands/file/iter.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 )
 
 // Iter extracts the filename from the parsed args and
@@ -43,7 +45,7 @@ func Iter(parsedArgs map[string]interface{}, cb func(map[string]interface{}) err
 	}
 
 	// Determine if we are following directories recursively.
-	recursive, _ := parsedArgs["--recursive"].(bool)
+	recursive := argutils.ArgBoolOrFalse(parsedArgs, "--recursive")
 
 	// Handle directory by walking the directory contents and performing the action on each manifest file.
 	return filepath.Walk(f,

--- a/calicoctl/commands/file/iter.go
+++ b/calicoctl/commands/file/iter.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Iter extracts the filename from the parsed args and
+// -  invokes the callback for each manifest files in the directory if the filename in the parsed arguments is a
+//    directory (updating the arguments to include the specific file)
+// -  otherwise just invoke the callback with the unmodified arguments.
+func Iter(parsedArgs map[string]interface{}, cb func(map[string]interface{}) error) error {
+	// File name is specified.
+	f, ok := parsedArgs["--filename"].(string)
+	if !ok {
+		// Handle invalid or missing filename by invoking standard processing.
+		return cb(parsedArgs)
+	}
+
+	if f == "-" {
+		// Handle stdin filename by invoking standard processing.
+		return cb(parsedArgs)
+	}
+
+	if !isDir(f) {
+		// Handle non-directory by invoking standard processing.
+		return cb(parsedArgs)
+	}
+
+	// Determine if we are following directories recursively.
+	recursive, _ := parsedArgs["--recursive"].(bool)
+
+	// Handle directory by walking the directory contents and performing the action on each manifest file.
+	return filepath.Walk(f,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if info.IsDir() {
+				// Return nil or SkipDir dpending on whether or not we are recursively following directories (note that
+				// we need to explicitly handle the root directory to ensure we do at least one layer of directory
+				// walking by default).
+				if recursive || path == f {
+					return nil
+				} else {
+					return filepath.SkipDir
+				}
+			}
+
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext == ".yaml" || ext == ".yml" || ext == ".json" {
+				return cb(newParsedArgs(parsedArgs, path))
+			}
+
+			return nil
+		})
+}
+
+// isDir returns true if the specified file path exists, is readable, and is a directory, otherwise returns false.
+func isDir(f string) bool {
+	if info, err := os.Stat(f); err != nil {
+		return false
+	} else {
+		return info.IsDir()
+	}
+}
+
+// newParsedArgs returns an updated set of arguments which include the specified filename.
+func newParsedArgs(original map[string]interface{}, newFilename string) map[string]interface{} {
+	out := make(map[string]interface{})
+	for k, v := range original {
+		out[k] = v
+	}
+	out["--filename"] = newFilename
+	return out
+}

--- a/calicoctl/commands/file/iter_test.go
+++ b/calicoctl/commands/file/iter_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file_test
+
+import (
+	"github.com/projectcalico/calicoctl/calicoctl/commands/file"
+
+	"errors"
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// Check handling of file or directory enumeration
+var _ = Describe("File and directory iteration", func() {
+	var fname string
+	var dname string
+	var dfname1, dfname2, dfname3 string
+	var df2name1, df2name2, df2name3 string
+	var invocations []map[string]interface{}
+	var testError error
+
+	BeforeEach(func() {
+		// Create a temporary file and directory with a couple of files for performing our tests
+		f, err := ioutil.TempFile(".", "testfile*")
+		Expect(err).NotTo(HaveOccurred())
+		fname = f.Name()
+		err = f.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		dname, err = ioutil.TempDir(".", "testdir*")
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err = ioutil.TempFile(dname, "testfile*.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		dfname1 = f.Name()
+		err = f.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err = ioutil.TempFile(dname, "testfile*.yml")
+		Expect(err).NotTo(HaveOccurred())
+		dfname2 = f.Name()
+		err = f.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err = ioutil.TempFile(dname, "testfile*.json")
+		Expect(err).NotTo(HaveOccurred())
+		dfname3 = f.Name()
+		err = f.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err = ioutil.TempFile(dname, "testfile*.txt")
+		Expect(err).NotTo(HaveOccurred())
+		err = f.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a sub-directory.
+		dname2, err := ioutil.TempDir(dname, "subdir*")
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err = ioutil.TempFile(dname2, "testfile*.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		df2name1 = f.Name()
+		err = f.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err = ioutil.TempFile(dname2, "testfile*.yml")
+		Expect(err).NotTo(HaveOccurred())
+		df2name2 = f.Name()
+		err = f.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err = ioutil.TempFile(dname2, "testfile*.json")
+		Expect(err).NotTo(HaveOccurred())
+		df2name3 = f.Name()
+		err = f.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err = ioutil.TempFile(dname2, "testfile*.txt")
+		Expect(err).NotTo(HaveOccurred())
+		err = f.Close()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Reset the callback invocations and test error
+		invocations = nil
+		testError = nil
+	})
+
+	AfterEach(func() {
+		Expect(os.Remove(fname)).ToNot(HaveOccurred())
+		Expect(os.RemoveAll(dname)).ToNot(HaveOccurred())
+	})
+
+	runTest := func(filename string, recursive bool, expected []string) error {
+		args := map[string]interface{}{
+			"--abc": 1,
+			"--def": "hello",
+		}
+		if filename != "" {
+			args["--filename"] = filename
+		}
+		if recursive {
+			args["--recursive"] = true
+		}
+
+		err := file.Iter(args, func(updated map[string]interface{}) error {
+			invocations = append(invocations, updated)
+			return testError
+		})
+		Expect(invocations).To(HaveLen(len(expected)))
+		for i := range invocations {
+			var count int
+			if filename == "" {
+				Expect(invocations[i]).NotTo(HaveKey("--filename"))
+				count = 2
+			} else {
+				Expect(invocations[i]).To(HaveKey("--filename"))
+				Expect(invocations[i]["--filename"]).To(BeElementOf(expected))
+				count = 3
+			}
+			if recursive {
+				count++
+			}
+			Expect(invocations[i]).To(HaveLen(count))
+			Expect(invocations[i]).To(HaveKey("--abc"))
+			Expect(invocations[i]["--abc"]).To(Equal(1))
+			Expect(invocations[i]["--def"]).To(Equal("hello"))
+		}
+		return err
+	}
+
+	It("should handle no filename", func() {
+		err := runTest("", false, []string{""})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should handle stdin", func() {
+		err := runTest("-", false, []string{"-"})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should handle non-existent file", func() {
+		err := runTest("this-file-should-not-exist", false, []string{"this-file-should-not-exist"})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should handle error", func() {
+		testError = errors.New("test")
+		err := runTest("-", false, []string{"-"})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should handle file", func() {
+		err := runTest(fname, false, []string{fname})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should handle directory and different file extensions", func() {
+		err := runTest(dname, false, []string{dfname1, dfname2, dfname3})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should handle directory and sub directories when running recursively", func() {
+		err := runTest(dname, true, []string{dfname1, dfname2, dfname3, df2name1, df2name2, df2name3})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -30,7 +30,7 @@ import (
 func Get(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl get ( (<KIND> [<NAME>...]) |
-                --filename=<FILENAME> [--recursive])
+                --filename=<FILENAME> [--recursive] [--skip-empty] )
                 [--output=<OUTPUT>] [--config=<CONFIG>] [--namespace=<NS>] [--all-namespaces] [--export]
 
 Examples:
@@ -47,6 +47,8 @@ Options:
                                invoked for each .json .yaml and .yml file within that directory,
                                terminating after the first failure.
   -R --recursive               Process the filename specified in -f or --filename recursively.
+     --skip-empty              Do not error if any files or directory specified using -f or --filename contain no
+                               data.
   -o --output=<OUTPUT FORMAT>  Output format.  One of: yaml, json, ps, wide,
                                custom-columns=..., go-template=...,
                                go-template-file=...   [Default: ps]

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -20,17 +20,17 @@ import (
 	"fmt"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
-
-	log "github.com/sirupsen/logrus"
 )
 
 func Get(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl get ( (<KIND> [<NAME>...]) |
-                --filename=<FILENAME>)
+                --filename=<FILENAME> [--recursive])
                 [--output=<OUTPUT>] [--config=<CONFIG>] [--namespace=<NS>] [--all-namespaces] [--export]
 
 Examples:
@@ -43,7 +43,10 @@ Examples:
 Options:
   -h --help                    Show this screen.
   -f --filename=<FILENAME>     Filename to use to get the resource.  If set to
-                               "-" loads from stdin.
+                               "-" loads from stdin. If filename is a directory, this command is
+                               invoked for each .json .yaml and .yml file within that directory,
+                               terminating after the first failure.
+  -R --recursive               Process the filename specified in -f or --filename recursively.
   -o --output=<OUTPUT FORMAT>  Output format.  One of: yaml, json, ps, wide,
                                custom-columns=..., go-template=...,
                                go-template-file=...   [Default: ps]

--- a/calicoctl/commands/ipam/release.go
+++ b/calicoctl/commands/ipam/release.go
@@ -22,6 +22,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/net"
 
 	docopt "github.com/docopt/docopt-go"
+
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"

--- a/calicoctl/commands/label.go
+++ b/calicoctl/commands/label.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	docopt "github.com/docopt/docopt-go"
+
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/resourcemgr"

--- a/calicoctl/commands/node/node_suite_test.go
+++ b/calicoctl/commands/node/node_suite_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 

--- a/calicoctl/commands/node/run.go
+++ b/calicoctl/commands/node/run.go
@@ -26,13 +26,14 @@ import (
 	"time"
 
 	"github.com/docopt/docopt-go"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/libcalico-go/lib/names"
 	"github.com/projectcalico/libcalico-go/lib/net"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/calicoctl/commands/node_linux.go
+++ b/calicoctl/commands/node_linux.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/docopt/docopt-go"
+
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/node"
 )

--- a/calicoctl/commands/patch.go
+++ b/calicoctl/commands/patch.go
@@ -19,9 +19,10 @@ import (
 	"strings"
 
 	"github.com/docopt/docopt-go"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
-	log "github.com/sirupsen/logrus"
 )
 
 func Patch(args []string) error {

--- a/calicoctl/commands/patch.go
+++ b/calicoctl/commands/patch.go
@@ -93,6 +93,10 @@ Description:
 	log.Infof("results: %+v", results)
 
 	if results.NumResources == 0 {
+		// No resources specified. If there is an associated error use that, otherwise print message with no error.
+		if results.Err != nil {
+			return results.Err
+		}
 		return fmt.Errorf("No resources specified")
 	} else if results.Err == nil && results.NumHandled > 0 {
 		fmt.Printf("Successfully patched %d '%s' resource\n", results.NumHandled, results.SingleKind)

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -21,14 +21,15 @@ import (
 
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
-	log "github.com/sirupsen/logrus"
 )
 
 func Replace(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl replace --filename=<FILENAME> [--config=<CONFIG>] [--namespace=<NS>]
+  calicoctl replace --filename=<FILENAME> [--recursive] [--config=<CONFIG>] [--namespace=<NS>]
 
 Examples:
   # Replace a policy using the data in policy.yaml.
@@ -40,7 +41,10 @@ Examples:
 Options:
   -h --help                  Show this screen.
   -f --filename=<FILENAME>   Filename to use to replace the resource.  If set
-                             to "-" loads from stdin.
+                             to "-" loads from stdin. If filename is a directory, this command is
+                             invoked for each .json .yaml and .yml file within that directory,
+                             terminating after the first failure.
+  -R --recursive             Process the filename specified in -f or --filename recursively.
   -c --config=<CONFIG>       Path to the file containing connection
                              configuration in YAML or JSON format.
                              [default: ` + constants.DefaultConfigPath + `]

--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/docopt/docopt-go"
+
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/libcalico-go/lib/options"

--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -25,18 +25,19 @@ import (
 	"strings"
 	"time"
 
-	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
-	yamlsep "github.com/projectcalico/calicoctl/calicoctl/util/yaml"
-	yaml "github.com/projectcalico/go-yaml-wrapper"
-	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
-	client "github.com/projectcalico/libcalico-go/lib/clientv3"
-	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+
+	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
+	yamlsep "github.com/projectcalico/calicoctl/calicoctl/util/yaml"
+	yaml "github.com/projectcalico/go-yaml-wrapper"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 )
 
 // ResourceManager provides a useful function for each resource type.  This includes:

--- a/calicoctl/resourcemgr/resourcemgr_test.go
+++ b/calicoctl/resourcemgr/resourcemgr_test.go
@@ -20,9 +20,10 @@ import (
 	"os"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/projectcalico/calicoctl/calicoctl/resourcemgr"
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
## Description
Added the ability to specify manifests by directory.

If the file is a directory, calicoctl will search for .yaml, .yml and .json files in the immediate directory, and optionally recursively search sub directories.  An additional option is also added to allow calicoctl to run without error if the specific file or directory are empty (note that if --filename points to a non-existent 

## Todos
- [X] Tests (ST)
- [ ] Documentation
- [ ] Release note

Could benefit from some STs I think.  We have UTs testing the actual file loading behavior.  Not planning to add STs for 3.16 though.

## Release Note

```release-note
Various commands using file input now support specifying a directory to support actions on multiple manifests, these commands also include optional recursive searches for .yaml, .yml and .json files, and additional options to disable failing if the files or directory contain no resources.
```
