### PR TITLE
Fix the default value of the K8s client QPS

### DIFF
--- a/calicoctl/commands/datastore/migrate/import.go
+++ b/calicoctl/commands/datastore/migrate/import.go
@@ -78,7 +78,7 @@ Description:
 	}
 
 	// Set the Kubernetes client QPS to 50 if not explicitly set.
-	if cfg.Spec.K8sClientQPS != float32(0) {
+	if cfg.Spec.K8sClientQPS == float32(0) {
 		cfg.Spec.K8sClientQPS = float32(50)
 	}
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fix a bug in setting the default K8s client QPS. The default is supposed to be 50, but the code mistakenly changes any other configured value to the intended default of 50 and sets the default to 5.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes a bug that prevented the K8s client QPS from being configured correctly.
```
