### PR TITLE
Add KubeControllersConfiguration to the datastore migration

### DIFF
--- a/calicoctl/commands/datastore/migrate/export.go
+++ b/calicoctl/commands/datastore/migrate/export.go
@@ -43,27 +43,29 @@ var allV3Resources []string = []string{
 	"globalnetworkpolicies",
 	"globalnetworksets",
 	"heps",
+	"kubecontrollersconfigs",
 	"networkpolicies",
 	"networksets",
 	"nodes",
 }
 
 var resourceDisplayMap map[string]string = map[string]string{
-	"ipamBlocks":            "IPAMBlocks",
-	"blockaffinities":       "BlockAffinities",
-	"ipamhandles":           "IPAMHandles",
-	"ipamconfigs":           "IPAMConfigurations",
-	"ippools":               "IPPools",
-	"bgpconfig":             "BGPConfigurations",
-	"bgppeers":              "BGPPeers",
-	"clusterinfos":          "ClusterInformations",
-	"felixconfigs":          "FelixConfigurations",
-	"globalnetworkpolicies": "GlobalNetworkPolicies",
-	"globalnetworksets":     "GlobalNetworkSets",
-	"heps":                  "HostEndpoints",
-	"networkpolicies":       "NetworkPolicies",
-	"networksets":           "Networksets",
-	"nodes":                 "Nodes",
+	"ipamBlocks":             "IPAMBlocks",
+	"blockaffinities":        "BlockAffinities",
+	"ipamhandles":            "IPAMHandles",
+	"ipamconfigs":            "IPAMConfigurations",
+	"ippools":                "IPPools",
+	"bgpconfig":              "BGPConfigurations",
+	"bgppeers":               "BGPPeers",
+	"clusterinfos":           "ClusterInformations",
+	"felixconfigs":           "FelixConfigurations",
+	"globalnetworkpolicies":  "GlobalNetworkPolicies",
+	"globalnetworksets":      "GlobalNetworkSets",
+	"heps":                   "HostEndpoints",
+	"kubecontrollersconfigs": "KubeControllersConfigurations",
+	"networkpolicies":        "NetworkPolicies",
+	"networksets":            "Networksets",
+	"nodes":                  "Nodes",
 }
 
 var namespacedResources map[string]struct{} = map[string]struct{}{
@@ -99,6 +101,7 @@ Description:
     - GlobalNetworkPolicies
     - GlobalNetworkSets
     - HostEndpoints
+    - KubeControllersConfigurations
     - NetworkPolicies
     - Networksets
     - Nodes


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Adds the KubeControllersConfiguration resource to the datastore migration.
Cherry-pick of https://github.com/projectcalico/calicoctl/pull/2173

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Datastore migration commands migrate KubeControllersConfiguration resources.
```
