### PR TITLE
Fix datastore migration to properly assign Kubernetes nodenames in the migrated IPAM data

### DIFF
--- a/calicoctl/commands/datastore/migrate/export.go
+++ b/calicoctl/commands/datastore/migrate/export.go
@@ -147,6 +147,7 @@ Description:
 	}
 
 	rp := common.ResourcePrinterYAML{}
+	etcdToKddNodeMap := make(map[string]string)
 	// Loop through all the resource types to retrieve every resource available by the v3 API.
 	for _, r := range allV3Resources {
 		mockArgs := map[string]interface{}{
@@ -229,6 +230,7 @@ Description:
 						return fmt.Errorf("Node %s missing a 'k8s' orchestrator reference. Unable to export data unless every node has a 'k8s' orchestrator reference", node.GetObjectMeta().GetName())
 					}
 
+					etcdToKddNodeMap[node.GetObjectMeta().GetName()] = newNodeName
 					node.GetObjectMeta().SetName(newNodeName)
 
 					return nil
@@ -297,6 +299,7 @@ Description:
 
 	// Use the v1 API in order to retrieve IPAM resources
 	ipam := NewMigrateIPAM(client)
+	ipam.SetNodeMap(etcdToKddNodeMap)
 	err = ipam.PullFromDatastore()
 	if err != nil {
 		return err

--- a/calicoctl/commands/datastore/migrate/export.go
+++ b/calicoctl/commands/datastore/migrate/export.go
@@ -35,6 +35,9 @@ import (
 )
 
 // All of the resources we can retrieve via the v3 API.
+// Any resources which have references to node names MUST come after
+// nodes since the Kubernetes node names are not known until after nodes
+// are processed.
 var allV3Resources []string = []string{
 	"ippools",
 	"bgpconfig",
@@ -241,6 +244,7 @@ Description:
 			}
 
 			// Felix configs may also need to be modified if node names do not match the Kubernetes node names.
+			// Felix configs must come after nodes in the allV3Resources list since we populate the node mapping when nodes are exported.
 			if r == "felixconfigs" {
 				err := meta.EachListItem(resource, func(obj runtime.Object) error {
 					felixConfig, ok := obj.(*apiv3.FelixConfiguration)

--- a/calicoctl/commands/datastore/migrate/migrateipam.go
+++ b/calicoctl/commands/datastore/migrate/migrateipam.go
@@ -137,16 +137,14 @@ func (m *migrateIPAM) PullFromDatastore() error {
 					block.Attributes[i].AttrSecondary["node"] = nodeName
 				}
 
-				// Update the handle ID for ipip tunnel addresses
+				// Update the handle ID for any tunnel addresses
 				if allocationAttribute.AttrPrimary != nil {
-					handlePrefixReplaced := false
 					for _, handlePrefix := range ipamHandlePrefixes {
-						if !handlePrefixReplaced && strings.HasPrefix(*allocationAttribute.AttrPrimary, handlePrefix) {
+						if strings.HasPrefix(*allocationAttribute.AttrPrimary, handlePrefix) {
 							etcdNodeName := strings.TrimPrefix(*allocationAttribute.AttrPrimary, handlePrefix)
 							if nodeName, ok := m.nodeMap[etcdNodeName]; ok {
 								handleID := fmt.Sprintf("%s%s", handlePrefix, nodeName)
 								block.Attributes[i].AttrPrimary = &handleID
-								handlePrefixReplaced = true
 							}
 						}
 					}
@@ -201,18 +199,16 @@ func (m *migrateIPAM) PullFromDatastore() error {
 
 	ipamHandles := []*IPAMHandleKVPair{}
 	for _, item := range ipamHandleKVList.KVPairs {
-		// Update IPAM handle ID for IPIP tunnel to include the Kubernetes node name.
+		// Update IPAM handle ID for a tunnel to include the Kubernetes node name.
 		key, ok := item.Key.(model.IPAMHandleKey)
 		if !ok {
 			return fmt.Errorf("Unable to convert %+v to an IPAMHandleKey", item.Key)
 		}
-		handlePrefixReplaced := false
 		for _, handlePrefix := range ipamHandlePrefixes {
-			if !handlePrefixReplaced && strings.HasPrefix(key.HandleID, handlePrefix) {
+			if strings.HasPrefix(key.HandleID, handlePrefix) {
 				etcdNodeName := strings.TrimPrefix(key.HandleID, handlePrefix)
 				if nodeName, ok := m.nodeMap[etcdNodeName]; ok {
 					key.HandleID = fmt.Sprintf("%s%s", handlePrefix, nodeName)
-					handlePrefixReplaced = true
 				}
 			}
 		}

--- a/calicoctl/commands/datastore/migrate/migrateipam.go
+++ b/calicoctl/commands/datastore/migrate/migrateipam.go
@@ -130,10 +130,20 @@ func (m *migrateIPAM) PullFromDatastore() error {
 		// Update node names in the block to match the Kubernetes node
 		if m.nodeMap != nil {
 			for i, allocationAttribute := range block.Attributes {
-				nodeName, ok := m.nodeMap[allocationAttribute.AttrSecondary["node"]]
-				// Do not update the node name if it does not exist
-				if ok {
+				// Update the node name if it has a corresponding Kubernetes node name
+				if nodeName, ok := m.nodeMap[allocationAttribute.AttrSecondary["node"]]; ok {
 					block.Attributes[i].AttrSecondary["node"] = nodeName
+				}
+
+				// Update the handle ID for ipip tunnel addresses
+				if allocationAttribute.AttrPrimary != nil {
+					if strings.HasPrefix(*allocationAttribute.AttrPrimary, "ipip-tunnel-addr-") {
+						etcdNodeName := strings.TrimPrefix(*allocationAttribute.AttrPrimary, "ipip-tunnel-addr-")
+						if nodeName, ok := m.nodeMap[etcdNodeName]; ok {
+							handleID := fmt.Sprintf("ipip-tunnel-addr-%s", nodeName)
+							block.Attributes[i].AttrPrimary = &handleID
+						}
+					}
 				}
 			}
 

--- a/calicoctl/commands/datastore/migrate/migrateipam.go
+++ b/calicoctl/commands/datastore/migrate/migrateipam.go
@@ -17,6 +17,7 @@ package migrate
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -29,6 +30,7 @@ import (
 
 type migrateIPAM struct {
 	client          bapi.Client
+	nodeMap         map[string]string
 	BlockAffinities []*BlockAffinityKVPair `json:"block_affinities,omitempty"`
 	IPAMBlocks      []*IPAMBlockKVPair     `json:"blocks,omitempty"`
 	IPAMHandles     []*IPAMHandleKVPair    `json:"handles,omitempty"`
@@ -82,6 +84,10 @@ func NewMigrateIPAM(c client.Interface) *migrateIPAM {
 	}
 }
 
+func (m *migrateIPAM) SetNodeMap(nodeMap map[string]string) {
+	m.nodeMap = nodeMap
+}
+
 func (m *migrateIPAM) PullFromDatastore() error {
 	ctx := context.Background()
 
@@ -120,6 +126,24 @@ func (m *migrateIPAM) PullFromDatastore() error {
 		if !ok {
 			return fmt.Errorf("Could not convert %+v to an AllocationBlock", item.Value)
 		}
+
+		// Update node names in the block to match the Kubernetes node
+		if m.nodeMap != nil {
+			for i, allocationAttribute := range block.Attributes {
+				nodeName, ok := m.nodeMap[allocationAttribute.AttrSecondary["node"]]
+				// Do not update the node name if it does not exist
+				if ok {
+					block.Attributes[i].AttrSecondary["node"] = nodeName
+				}
+			}
+
+			nodeName, ok := m.nodeMap[block.Host()]
+			if ok {
+				affinityName := fmt.Sprintf("host:%s", nodeName)
+				block.Affinity = &affinityName
+			}
+		}
+
 		blocks = append(blocks, &IPAMBlockKVPair{
 			Key:   blockKey,
 			Value: block,
@@ -129,7 +153,20 @@ func (m *migrateIPAM) PullFromDatastore() error {
 
 	blockAffinities := []*BlockAffinityKVPair{}
 	for _, item := range blockAffinityKVList.KVPairs {
-		blockAffinityKey, err := model.KeyToDefaultPath(item.Key)
+		etcdBlockAffinityKey, ok := item.Key.(model.BlockAffinityKey)
+		if !ok {
+			return fmt.Errorf("Error converting Key to BlockAffinityKey: %+v", item.Key)
+		}
+
+		// Update the block affinity to match the Kubernetes node names.
+		if m.nodeMap != nil {
+			nodeName, ok := m.nodeMap[etcdBlockAffinityKey.Host]
+			if ok {
+				etcdBlockAffinityKey.Host = nodeName
+			}
+		}
+
+		blockAffinityKey, err := model.KeyToDefaultPath(etcdBlockAffinityKey)
 		if err != nil {
 			return fmt.Errorf("Error serializing BlockAffinityKey: %s", err)
 		}
@@ -138,6 +175,7 @@ func (m *migrateIPAM) PullFromDatastore() error {
 		if !ok {
 			return fmt.Errorf("Could not convert %+v to a BlockAffinity", item.Value)
 		}
+
 		blockAffinities = append(blockAffinities, &BlockAffinityKVPair{
 			Key:   blockAffinityKey,
 			Value: blockAffinity,
@@ -147,10 +185,23 @@ func (m *migrateIPAM) PullFromDatastore() error {
 
 	ipamHandles := []*IPAMHandleKVPair{}
 	for _, item := range ipamHandleKVList.KVPairs {
-		handleKey, err := model.KeyToDefaultPath(item.Key)
+		// Update IPAM handle ID for IPIP tunnel to include the Kubernetes node name.
+		key, ok := item.Key.(model.IPAMHandleKey)
+		if !ok {
+			return fmt.Errorf("Unable to convert %+v to an IPAMHandleKey", item.Key)
+		}
+		if strings.HasPrefix(key.HandleID, "ipip-tunnel-addr-") {
+			etcdNodeName := strings.TrimPrefix(key.HandleID, "ipip-tunnel-addr-")
+			if nodeName, ok := m.nodeMap[etcdNodeName]; ok {
+				key.HandleID = fmt.Sprintf("ipip-tunnel-addr-%s", nodeName)
+			}
+		}
+
+		handleKey, err := model.KeyToDefaultPath(key)
 		if err != nil {
 			return fmt.Errorf("Error serializing IPAMHandleKey: %s", err)
 		}
+
 		handle, ok := item.Value.(*model.IPAMHandle)
 		if !ok {
 			return fmt.Errorf("Could not convert %+v to an IPAMHandle", item.Value)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fixes issues where the etcd node names did not match the Kubernetes datastore node names. This migrates all of the relevant host information in IPAM to the correct Kubernetes datastore node name. This inserts the new Kubernetes datastore node names into the following IPAM fields:
- IPAM block allocation attributes
- IPAM block block affinity field
- IPAM block affinity host field
- IPAM block handle ID for `ipip-tunnel-addr` handles
- IPAM handle ID for `ipip-tunnel-addr` handles

This also fixes a similar issue where node names were not migrated properly for per-node FelixConfigurations.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix a bug with mismatched node names when migrating IPAM data from etcd to Kubernetes datastores.
```
