### PR TITLE
Add handling for v1 validations and node names in BGP configurations

### DIFF
--- a/calicoctl/commands/datastore/migrate/export.go
+++ b/calicoctl/commands/datastore/migrate/export.go
@@ -259,6 +259,9 @@ Description:
 						}
 					}
 
+					// Handling for possibly misconfigured iptables values from the v1 API.
+					ConvertIptablesFields(felixConfig)
+
 					return nil
 				})
 				if err != nil {
@@ -363,4 +366,19 @@ Description:
 	}
 
 	return nil
+}
+
+// ConvertIptablesFields ensures that all iptables fields are valid for the v3 API.
+func ConvertIptablesFields(felixConfig *apiv3.FelixConfiguration) {
+	if felixConfig.Spec.DefaultEndpointToHostAction != "" {
+		felixConfig.Spec.DefaultEndpointToHostAction = strings.Title(strings.ToLower(felixConfig.Spec.DefaultEndpointToHostAction))
+	}
+
+	if felixConfig.Spec.IptablesFilterAllowAction != "" {
+		felixConfig.Spec.IptablesFilterAllowAction = strings.Title(strings.ToLower(felixConfig.Spec.IptablesFilterAllowAction))
+	}
+
+	if felixConfig.Spec.IptablesMangleAllowAction != "" {
+		felixConfig.Spec.IptablesMangleAllowAction = strings.Title(strings.ToLower(felixConfig.Spec.IptablesMangleAllowAction))
+	}
 }

--- a/calicoctl/commands/datastore/migrate/export_test.go
+++ b/calicoctl/commands/datastore/migrate/export_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate_test
+
+import (
+	"github.com/projectcalico/calicoctl/calicoctl/commands/datastore/migrate"
+
+	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Etcd to KDD Migration Export handling", func() {
+	Context("with v1 API iptables values in the FelixConfiguration", func() {
+		It("Should properly convert v1 API iptables values to v3 API values", func() {
+			felixConfig := apiv3.NewFelixConfiguration()
+			felixConfig.Spec = apiv3.FelixConfigurationSpec{
+				DefaultEndpointToHostAction: "DROP",
+				IptablesFilterAllowAction:   "ACCEPT",
+				IptablesMangleAllowAction:   "RETURN",
+			}
+
+			migrate.ConvertIptablesFields(felixConfig)
+			Expect(felixConfig.Spec.DefaultEndpointToHostAction).To(Equal("Drop"))
+			Expect(felixConfig.Spec.IptablesFilterAllowAction).To(Equal("Accept"))
+			Expect(felixConfig.Spec.IptablesMangleAllowAction).To(Equal("Return"))
+		})
+
+		It("Should not change v3 API iptables values", func() {
+			felixConfig := apiv3.NewFelixConfiguration()
+			felixConfig.Spec = apiv3.FelixConfigurationSpec{
+				DefaultEndpointToHostAction: "Drop",
+				IptablesFilterAllowAction:   "ACCEPT",
+				IptablesMangleAllowAction:   "Return",
+			}
+
+			migrate.ConvertIptablesFields(felixConfig)
+			Expect(felixConfig.Spec.DefaultEndpointToHostAction).To(Equal("Drop"))
+			Expect(felixConfig.Spec.IptablesFilterAllowAction).To(Equal("Accept"))
+			Expect(felixConfig.Spec.IptablesMangleAllowAction).To(Equal("Return"))
+		})
+
+		It("Should not change any values if no iptables values are set", func() {
+			felixConfig := apiv3.NewFelixConfiguration()
+			felixConfig.Spec = apiv3.FelixConfigurationSpec{}
+
+			migrate.ConvertIptablesFields(felixConfig)
+			Expect(felixConfig.Spec.DefaultEndpointToHostAction).To(Equal(""))
+			Expect(felixConfig.Spec.IptablesFilterAllowAction).To(Equal(""))
+			Expect(felixConfig.Spec.IptablesMangleAllowAction).To(Equal(""))
+		})
+	})
+})

--- a/calicoctl/commands/datastore/migrate/migrate_suite_test.go
+++ b/calicoctl/commands/datastore/migrate/migrate_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	"github.com/onsi/ginkgo/reporters"
+)
+
+func TestCommands(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../report/migrate_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Migrate Suite", []Reporter{junitReporter})
+}

--- a/calicoctl/commands/datastore/migrate/migrateipam_test.go
+++ b/calicoctl/commands/datastore/migrate/migrateipam_test.go
@@ -31,10 +31,10 @@ import (
 )
 
 var (
-	nodeName           = "original-node"
-	newNodeName        = "changed-node"
+	nodeName           = "etcdNodeName"
+	newNodeName        = "k8sNodeName"
 	blockAffinityField = fmt.Sprintf("host:%s", nodeName)
-	ipipTunnelHandle   = "ipip-tunnel-addr-original-node"
+	ipipTunnelHandle   = "ipip-tunnel-addr-etcdNodeName"
 )
 
 var _ = Describe("IPAM migration handling", func() {
@@ -55,7 +55,7 @@ var _ = Describe("IPAM migration handling", func() {
 					{
 						AttrPrimary: &ipipTunnelHandle,
 						AttrSecondary: map[string]string{
-							"node": "original-node",
+							"node": nodeName,
 							"type": "ipipTunnelAddress",
 						},
 					},
@@ -150,20 +150,20 @@ var _ = Describe("IPAM migration handling", func() {
 		err := migrateIPAM.PullFromDatastore()
 		Expect(err).NotTo(HaveOccurred())
 
-		// Check that the block attributes were changed correctly
+		// Check that the block attributes were not changed
 		Expect(migrateIPAM.IPAMBlocks).To(HaveLen(1))
 		Expect(*migrateIPAM.IPAMBlocks[0].Value.Affinity).To(Equal(fmt.Sprintf("host:%s", nodeName)))
 		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes).To(HaveLen(1))
 		Expect(*migrateIPAM.IPAMBlocks[0].Value.Attributes[0].AttrPrimary).To(Equal(fmt.Sprintf("ipip-tunnel-addr-%s", nodeName)))
 		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes[0].AttrSecondary["node"]).To(Equal(nodeName))
 
-		// Check that the block affinity attributes were changed correctly
+		// Check that the block affinity attributes were not changed
 		newAffinityKeyPath, err := model.KeyToDefaultPath(affinity1.Key)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(migrateIPAM.BlockAffinities).To(HaveLen(1))
 		Expect(migrateIPAM.BlockAffinities[0].Key).To(Equal(newAffinityKeyPath))
 
-		// Check that the IPAM handle attributes were changed correctly
+		// Check that the IPAM handle attributes were not changed
 		newHandleKeyPath, err := model.KeyToDefaultPath(handle1.Key)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(migrateIPAM.IPAMHandles).To(HaveLen(1))

--- a/calicoctl/commands/datastore/migrate/migrateipam_test.go
+++ b/calicoctl/commands/datastore/migrate/migrateipam_test.go
@@ -1,0 +1,342 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/projectcalico/calicoctl/calicoctl/commands/datastore/migrate"
+
+	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/ipam"
+	"github.com/projectcalico/libcalico-go/lib/net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	nodeName           = "original-node"
+	newNodeName        = "changed-node"
+	blockAffinityField = fmt.Sprintf("host:%s", nodeName)
+	ipipTunnelHandle   = "ipip-tunnel-addr-original-node"
+)
+
+var _ = Describe("IPAM migration handling", func() {
+	var block1 *model.KVPair
+	var affinity1 *model.KVPair
+	var handle1 *model.KVPair
+
+	// Reset the IPAM information before each test
+	BeforeEach(func() {
+		block1 = &model.KVPair{
+			Key: model.BlockKey{
+				CIDR: net.MustParseCIDR("192.168.201.0/26"),
+			},
+			Value: &model.AllocationBlock{
+				CIDR:     net.MustParseCIDR("192.168.201.0/26"),
+				Affinity: &blockAffinityField,
+				Attributes: []model.AllocationAttribute{
+					{
+						AttrPrimary: &ipipTunnelHandle,
+						AttrSecondary: map[string]string{
+							"node": "original-node",
+							"type": "ipipTunnelAddress",
+						},
+					},
+				},
+			},
+		}
+
+		affinity1 = &model.KVPair{
+			Key: model.BlockAffinityKey{
+				CIDR: net.MustParseCIDR("192.168.201.0/26"),
+				Host: nodeName,
+			},
+			Value: &model.BlockAffinity{
+				State:   model.StateConfirmed,
+				Deleted: false,
+			},
+		}
+
+		handle1 = &model.KVPair{
+			Key: model.IPAMHandleKey{
+				HandleID: ipipTunnelHandle,
+			},
+			Value: &model.IPAMHandle{
+				Block: map[string]int{
+					"192.168.201.0/26": 1,
+				},
+				Deleted: false,
+			},
+		}
+	})
+
+	It("Should replace the node names in the IPAM block, block affinity, and handle", func() {
+		blocks := model.KVPairList{
+			KVPairs: []*model.KVPair{block1},
+		}
+		affinities := model.KVPairList{
+			KVPairs: []*model.KVPair{affinity1},
+		}
+		handles := model.KVPairList{
+			KVPairs: []*model.KVPair{handle1},
+		}
+
+		bc := NewMockIPAMBackendClient(blocks, affinities, handles)
+		client := NewMockIPAMClient(bc)
+		migrateIPAM := migrate.NewMigrateIPAM(client)
+		migrateIPAM.SetNodeMap(map[string]string{nodeName: newNodeName})
+		err := migrateIPAM.PullFromDatastore()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check that the block attributes were changed correctly
+		Expect(migrateIPAM.IPAMBlocks).To(HaveLen(1))
+		Expect(*migrateIPAM.IPAMBlocks[0].Value.Affinity).To(Equal(fmt.Sprintf("host:%s", newNodeName)))
+		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes).To(HaveLen(1))
+		Expect(*migrateIPAM.IPAMBlocks[0].Value.Attributes[0].AttrPrimary).To(Equal(fmt.Sprintf("ipip-tunnel-addr-%s", newNodeName)))
+		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes[0].AttrSecondary["node"]).To(Equal(newNodeName))
+
+		// Check that the block affinity attributes were changed correctly
+		newAffinityKey := model.BlockAffinityKey{
+			CIDR: net.MustParseCIDR("192.168.201.0/26"),
+			Host: newNodeName,
+		}
+		newAffinityKeyPath, err := model.KeyToDefaultPath(newAffinityKey)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migrateIPAM.BlockAffinities).To(HaveLen(1))
+		Expect(migrateIPAM.BlockAffinities[0].Key).To(Equal(newAffinityKeyPath))
+
+		// Check that the IPAM handle attributes were changed correctly
+		newHandleKey := model.IPAMHandleKey{
+			HandleID: fmt.Sprintf("ipip-tunnel-addr-%s", newNodeName),
+		}
+		newHandleKeyPath, err := model.KeyToDefaultPath(newHandleKey)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migrateIPAM.IPAMHandles).To(HaveLen(1))
+		Expect(migrateIPAM.IPAMHandles[0].Key).To(Equal(newHandleKeyPath))
+	})
+
+	It("Should not replace the node names in the IPAM block, block affinity, and handle if the node names are the same", func() {
+		blocks := model.KVPairList{
+			KVPairs: []*model.KVPair{block1},
+		}
+		affinities := model.KVPairList{
+			KVPairs: []*model.KVPair{affinity1},
+		}
+		handles := model.KVPairList{
+			KVPairs: []*model.KVPair{handle1},
+		}
+
+		bc := NewMockIPAMBackendClient(blocks, affinities, handles)
+		client := NewMockIPAMClient(bc)
+		migrateIPAM := migrate.NewMigrateIPAM(client)
+		migrateIPAM.SetNodeMap(map[string]string{nodeName: nodeName})
+		err := migrateIPAM.PullFromDatastore()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check that the block attributes were changed correctly
+		Expect(migrateIPAM.IPAMBlocks).To(HaveLen(1))
+		Expect(*migrateIPAM.IPAMBlocks[0].Value.Affinity).To(Equal(fmt.Sprintf("host:%s", nodeName)))
+		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes).To(HaveLen(1))
+		Expect(*migrateIPAM.IPAMBlocks[0].Value.Attributes[0].AttrPrimary).To(Equal(fmt.Sprintf("ipip-tunnel-addr-%s", nodeName)))
+		Expect(migrateIPAM.IPAMBlocks[0].Value.Attributes[0].AttrSecondary["node"]).To(Equal(nodeName))
+
+		// Check that the block affinity attributes were changed correctly
+		newAffinityKeyPath, err := model.KeyToDefaultPath(affinity1.Key)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migrateIPAM.BlockAffinities).To(HaveLen(1))
+		Expect(migrateIPAM.BlockAffinities[0].Key).To(Equal(newAffinityKeyPath))
+
+		// Check that the IPAM handle attributes were changed correctly
+		newHandleKeyPath, err := model.KeyToDefaultPath(handle1.Key)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(migrateIPAM.IPAMHandles).To(HaveLen(1))
+		Expect(migrateIPAM.IPAMHandles[0].Key).To(Equal(newHandleKeyPath))
+	})
+})
+
+// MockIPAMClient subs out the clientv3.Interface but only in a way where'
+// the bapi.Client is available for IPAM migration tests.
+type MockIPAMClient struct {
+	backend bapi.Client
+}
+
+func NewMockIPAMClient(bc bapi.Client) client.Interface {
+	return &MockIPAMClient{
+		backend: bc,
+	}
+}
+
+func (c *MockIPAMClient) Backend() bapi.Client {
+	return c.backend
+}
+
+func (c *MockIPAMClient) Nodes() client.NodeInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) GlobalNetworkPolicies() client.GlobalNetworkPolicyInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) NetworkPolicies() client.NetworkPolicyInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) IPPools() client.IPPoolInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) Profiles() client.ProfileInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) GlobalNetworkSets() client.GlobalNetworkSetInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) NetworkSets() client.NetworkSetInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) HostEndpoints() client.HostEndpointInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) WorkloadEndpoints() client.WorkloadEndpointInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) BGPPeers() client.BGPPeerInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) IPAM() ipam.Interface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) BGPConfigurations() client.BGPConfigurationInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) FelixConfigurations() client.FelixConfigurationInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) ClusterInformation() client.ClusterInformationInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) KubeControllersConfiguration() client.KubeControllersConfigurationInterface {
+	// DO NOTHING
+	return nil
+}
+
+func (c *MockIPAMClient) EnsureInitialized(ctx context.Context, calicoVersion, clusterType string) error {
+	// DO NOTHING
+	return nil
+}
+
+// MockIPAMBackendClient stubs out bapi.Client but only implements List
+// for the IPAM objects in order to test IPAM migration logic.
+type MockIPAMBackendClient struct {
+	blocks     model.KVPairList
+	affinities model.KVPairList
+	handles    model.KVPairList
+}
+
+func NewMockIPAMBackendClient(blocks model.KVPairList, affinities model.KVPairList, handles model.KVPairList) bapi.Client {
+	return &MockIPAMBackendClient{
+		blocks:     blocks,
+		affinities: affinities,
+		handles:    handles,
+	}
+}
+
+func (bc *MockIPAMBackendClient) Create(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	// DO NOTHING
+	return object, nil
+}
+
+func (bc *MockIPAMBackendClient) Update(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	// DO NOTHING
+	return object, nil
+}
+
+func (bc *MockIPAMBackendClient) Apply(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	// DO NOTHING
+	return object, nil
+}
+
+func (bc *MockIPAMBackendClient) Delete(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	// DO NOTHING
+	return nil, nil
+}
+
+func (bc *MockIPAMBackendClient) DeleteKVP(ctx context.Context, object *model.KVPair) (*model.KVPair, error) {
+	// DO NOTHING
+	return object, nil
+}
+
+func (bc *MockIPAMBackendClient) Get(ctx context.Context, key model.Key, revision string) (*model.KVPair, error) {
+	// DO NOTHING
+	return nil, nil
+}
+
+func (bc *MockIPAMBackendClient) List(ctx context.Context, list model.ListInterface, revision string) (*model.KVPairList, error) {
+	// Since this is a mock client, we only return the values based on the type of the ListInterface
+	switch list.(type) {
+	case model.BlockListOptions:
+		return &bc.blocks, nil
+	case model.BlockAffinityListOptions:
+		return &bc.affinities, nil
+	case model.IPAMHandleListOptions:
+		return &bc.handles, nil
+	}
+	return nil, nil
+}
+
+func (bc *MockIPAMBackendClient) Watch(ctx context.Context, list model.ListInterface, revision string) (bapi.WatchInterface, error) {
+	// DO NOTHING
+	return bapi.NewFake(), nil
+}
+
+func (bc *MockIPAMBackendClient) EnsureInitialized() error {
+	// DO NOTHING
+	return nil
+}
+
+func (bc *MockIPAMBackendClient) Clean() error {
+	// DO NOTHING
+	return nil
+}

--- a/tests/st/calicoctl/test_migrate.py
+++ b/tests/st/calicoctl/test_migrate.py
@@ -55,6 +55,15 @@ class TestCalicoctlMigrate(TestBase):
         rc = calicoctl("get bgpconfig -o yaml")
         rc.assert_list("BGPConfiguration", [bgpconfig_name1_rev1])
 
+        # Create a BGP Config that should reference a node.
+        # This node reference will change since the node's orchrefs reference a different node.
+        rc = calicoctl("create", data=bgpconfig_name3_rev1)
+        rc.assert_no_error()
+        rc = calicoctl("get bgpconfig %s -o yaml" % name(bgpconfig_name3_rev1))
+        rc.assert_data(bgpconfig_name3_rev1)
+        rc = calicoctl("get bgpconfig -o yaml")
+        rc.assert_list("BGPConfiguration", [bgpconfig_name1_rev1, bgpconfig_name3_rev1])
+
         # Create a BGP Peer
         rc = calicoctl("create", data=bgppeer_name1_rev1_v4)
         rc.assert_no_error()
@@ -67,6 +76,13 @@ class TestCalicoctlMigrate(TestBase):
         rc = calicoctl("create", data=felixconfig_name1_rev1)
         rc.assert_no_error()
         rc = calicoctl("get felixconfig %s -o yaml" % name(felixconfig_name1_rev1))
+        rc.assert_no_error()
+
+        # Create a Felix config that should reference a node.
+        # This node reference will change since the node's orchrefs reference a different node.
+        rc = calicoctl("create", data=felixconfig_name2_rev1)
+        rc.assert_no_error()
+        rc = calicoctl("get felixconfig %s -o yaml" % name(felixconfig_name2_rev1))
         rc.assert_no_error()
 
         # Create a Global Network policy
@@ -141,9 +157,13 @@ class TestCalicoctlMigrate(TestBase):
         rc.assert_no_error()
         rc = calicoctl("delete bgpconfig %s" % name(bgpconfig_name1_rev1))
         rc.assert_no_error()
+        rc = calicoctl("delete bgpconfig %s" % name(bgpconfig_name3_rev1))
+        rc.assert_no_error()
         rc = calicoctl("delete bgppeer %s" % name(bgppeer_name1_rev1_v4))
         rc.assert_no_error()
         rc = calicoctl("delete felixconfig %s" % name(felixconfig_name1_rev1))
+        rc.assert_no_error()
+        rc = calicoctl("delete felixconfig %s" % name(felixconfig_name2_rev1))
         rc.assert_no_error()
         rc = calicoctl("delete globalnetworkpolicy %s" % name(globalnetworkpolicy_name1_rev1))
         rc.assert_no_error()
@@ -173,9 +193,19 @@ class TestCalicoctlMigrate(TestBase):
         rc.assert_data(ippool_name2_rev1_v6)
         rc = calicoctl("get bgpconfig %s -o yaml" % name(bgpconfig_name1_rev1), kdd=True)
         rc.assert_data(bgpconfig_name1_rev1)
+        # bgpconfig_name3_rev1 should be changed to bgpconfig_name4_rev1
+        rc = calicoctl("get bgpconfig %s -o yaml" % name(bgpconfig_name3_rev1), kdd=True)
+        rc.assert_error(text=NOT_FOUND)
+        rc = calicoctl("get bgpconfig %s -o yaml" % name(bgpconfig_name4_rev1), kdd=True)
+        rc.assert_no_error()
         rc = calicoctl("get bgppeer %s -o yaml" % name(bgppeer_name1_rev1_v4), kdd=True)
         rc.assert_data(bgppeer_name1_rev1_v4)
         rc = calicoctl("get felixconfig %s -o yaml" % name(felixconfig_name1_rev1), kdd=True)
+        rc.assert_no_error()
+        # felixconfig_name2_rev1 should be changed to felixconfig_name3_rev1
+        rc = calicoctl("get felixconfig %s -o yaml" % name(felixconfig_name2_rev1), kdd=True)
+        rc.assert_error(text=NOT_FOUND)
+        rc = calicoctl("get felixconfig %s -o yaml" % name(felixconfig_name3_rev1), kdd=True)
         rc.assert_no_error()
         rc = calicoctl("get globalnetworkpolicy %s -o yaml" % name(globalnetworkpolicy_name1_rev1), kdd=True)
         rc.assert_data(globalnetworkpolicy_name1_rev1)
@@ -203,9 +233,13 @@ class TestCalicoctlMigrate(TestBase):
         rc.assert_no_error()
         rc = calicoctl("delete bgpconfig %s" % name(bgpconfig_name1_rev1), kdd=True)
         rc.assert_no_error()
+        rc = calicoctl("delete bgpconfig %s" % name(bgpconfig_name4_rev1), kdd=True)
+        rc.assert_no_error()
         rc = calicoctl("delete bgppeer %s" % name(bgppeer_name1_rev1_v4), kdd=True)
         rc.assert_no_error()
         rc = calicoctl("delete felixconfig %s" % name(felixconfig_name1_rev1), kdd=True)
+        rc.assert_no_error()
+        rc = calicoctl("delete felixconfig %s" % name(felixconfig_name3_rev1), kdd=True)
         rc.assert_no_error()
         rc = calicoctl("delete globalnetworkpolicy %s" % name(globalnetworkpolicy_name1_rev1), kdd=True)
         rc.assert_no_error()

--- a/tests/st/utils/data.py
+++ b/tests/st/utils/data.py
@@ -687,7 +687,7 @@ node_name5_rev1 = {
         },
         'orchRefs': [
             {
-                'nodeName': 'node5',
+                'nodeName': 'node4',
                 'orchestrator': 'k8s',
             },
         ],
@@ -754,6 +754,28 @@ bgpconfig_name2_rev3 = {
     'spec': {
         'logSeverityScreen': 'Debug',
         'nodeToNodeMeshEnabled': True,
+    }
+}
+
+bgpconfig_name3_rev1 = {
+    'apiVersion': API_VERSION,
+    'kind': 'BGPConfiguration',
+    'metadata': {
+        'name': 'node.node5',
+    },
+    'spec': {
+        'logSeverityScreen': 'Debug',
+    }
+}
+
+bgpconfig_name4_rev1 = {
+    'apiVersion': API_VERSION,
+    'kind': 'BGPConfiguration',
+    'metadata': {
+        'name': 'node.node4',
+    },
+    'spec': {
+        'logSeverityScreen': 'Debug',
     }
 }
 
@@ -832,6 +854,98 @@ felixconfig_name1_rev3 = {
         'logSeverityScreen': 'Debug',
         'netlinkTimeout': '125s',
         'reportingTTL': '9910s',
+    }
+}
+
+felixconfig_name2_rev1 = {
+    'apiVersion': API_VERSION,
+    'kind': 'FelixConfiguration',
+    'metadata': {
+        'name': 'node.node5',
+    },
+    'spec': {
+        'chainInsertMode': 'append',
+        'defaultEndpointToHostAction': 'Accept',
+        'failsafeInboundHostPorts': [
+            {'protocol': 'TCP', 'port': 666},
+            {'protocol': 'UDP', 'port': 333}, ],
+        'failsafeOutboundHostPorts': [
+            {'protocol': 'TCP', 'port': 999},
+            {'protocol': 'UDP', 'port': 222},
+            {'protocol': 'UDP', 'port': 422}, ],
+        'interfacePrefix': 'humperdink',
+        'ipipMTU': 1521,
+        'ipsetsRefreshInterval': '44s',
+        'iptablesFilterAllowAction': 'Return',
+        'iptablesLockFilePath': '/run/fun',
+        'iptablesLockProbeInterval': '500ms',
+        'iptablesLockTimeout': '22s',
+        'iptablesMangleAllowAction': 'Accept',
+        'iptablesMarkMask': 0xff0000,
+        'iptablesPostWriteCheckInterval': '12s',
+        'iptablesRefreshInterval': '22s',
+        'ipv6Support': True,
+        'logFilePath': '/var/log/fun.log',
+        'logPrefix': 'say-hello-friend',
+        'logSeverityScreen': 'Info',
+        'maxIpsetSize': 8192,
+        'metadataAddr': '127.1.1.1',
+        'metadataPort': 8999,
+        'netlinkTimeout': '10s',
+        'prometheusGoMetricsEnabled': True,
+        'prometheusMetricsEnabled': True,
+        'prometheusMetricsPort': 11,
+        'prometheusProcessMetricsEnabled': True,
+        'reportingInterval': '10s',
+        'reportingTTL': '99s',
+        'routeRefreshInterval': '33s',
+        'usageReportingEnabled': False,
+    }
+}
+
+felixconfig_name3_rev1 = {
+    'apiVersion': API_VERSION,
+    'kind': 'FelixConfiguration',
+    'metadata': {
+        'name': 'node.node4',
+    },
+    'spec': {
+        'chainInsertMode': 'append',
+        'defaultEndpointToHostAction': 'Accept',
+        'failsafeInboundHostPorts': [
+            {'protocol': 'TCP', 'port': 666},
+            {'protocol': 'UDP', 'port': 333}, ],
+        'failsafeOutboundHostPorts': [
+            {'protocol': 'TCP', 'port': 999},
+            {'protocol': 'UDP', 'port': 222},
+            {'protocol': 'UDP', 'port': 422}, ],
+        'interfacePrefix': 'humperdink',
+        'ipipMTU': 1521,
+        'ipsetsRefreshInterval': '44s',
+        'iptablesFilterAllowAction': 'Return',
+        'iptablesLockFilePath': '/run/fun',
+        'iptablesLockProbeInterval': '500ms',
+        'iptablesLockTimeout': '22s',
+        'iptablesMangleAllowAction': 'Accept',
+        'iptablesMarkMask': 0xff0000,
+        'iptablesPostWriteCheckInterval': '12s',
+        'iptablesRefreshInterval': '22s',
+        'ipv6Support': True,
+        'logFilePath': '/var/log/fun.log',
+        'logPrefix': 'say-hello-friend',
+        'logSeverityScreen': 'Info',
+        'maxIpsetSize': 8192,
+        'metadataAddr': '127.1.1.1',
+        'metadataPort': 8999,
+        'netlinkTimeout': '10s',
+        'prometheusGoMetricsEnabled': True,
+        'prometheusMetricsEnabled': True,
+        'prometheusMetricsPort': 11,
+        'prometheusProcessMetricsEnabled': True,
+        'reportingInterval': '10s',
+        'reportingTTL': '99s',
+        'routeRefreshInterval': '33s',
+        'usageReportingEnabled': False,
     }
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Cherry-pick of #2199

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add handling for migrating per-node BGP configurations and Calico v1 API Felix configuration fields
```
