### PR TITLE
Handle docstring binary name changes for kubectl plugin

### DIFF
--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -23,11 +23,13 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 func main() {
-	doc := `Usage:
-  calicoctl [options] <command> [<args>...]
+	name, desc := util.NameAndDescription()
+	doc := fmt.Sprintf(`Usage:
+  <BINARY_NAME> [options] <command> [<args>...]
 
     create       Create a resource by file, directory or stdin.
     replace      Replace a resource by file, directory or stdin.
@@ -42,7 +44,7 @@ func main() {
     convert      Convert config files between different API versions.
     ipam         IP address management.
     node         Calico node management.
-    version      Display the version of calicoctl.
+    version      Display the version of this binary.
     export       Export the Calico datastore objects for migration
     import       Import the Calico datastore objects for migration
     datastore    Calico datastore management.
@@ -53,17 +55,21 @@ Options:
                           warn, info, debug) [default: panic]
 
 Description:
-  The calicoctl command line tool is used to manage Calico network and security
+  The %s is used to manage Calico network and security
   policy, to view and manage endpoint configuration, and to manage a Calico
   node instance.
 
-  See 'calicoctl <command> --help' to read about a specific subcommand.
-`
+  See '<BINARY_NAME> <command> --help' to read about a specific subcommand.
+`, desc)
+
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	arguments, err := docopt.Parse(doc, nil, true, commands.VERSION_SUMMARY, true, false)
 	if err != nil {
 		if _, ok := err.(*docopt.UserError); ok {
 			// the user gave us bad input
-			fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(os.Args[1:], " "))
+			fmt.Printf("Invalid option: '%s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(os.Args[1:], " "))
 		}
 		os.Exit(1)
 	}

--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -23,19 +23,20 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 func Apply(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl apply --filename=<FILENAME> [--recursive] [--skip-empty]
+  <BINARY_NAME> apply --filename=<FILENAME> [--recursive] [--skip-empty]
                   [--config=<CONFIG>] [--namespace=<NS>]
 
 Examples:
   # Apply a policy using the data in policy.yaml.
-  calicoctl apply -f ./policy.yaml
+  <BINARY_NAME> apply -f ./policy.yaml
 
   # Apply a policy based on the JSON passed into stdin.
-  cat policy.json | calicoctl apply -f -
+  cat policy.json | <BINARY_NAME> apply -f -
 
 Options:
   -h --help                 Show this screen.
@@ -90,6 +91,10 @@ Description:
   must be provided, it is not sufficient to supply only the fields that are
   being updated.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/convert.go
+++ b/calicoctl/commands/convert.go
@@ -27,6 +27,7 @@ import (
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/v1resourceloader"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 	"github.com/projectcalico/libcalico-go/lib/apis/v1/unversioned"
 	"github.com/projectcalico/libcalico-go/lib/upgrade/converters"
 	validator "github.com/projectcalico/libcalico-go/lib/validator/v3"
@@ -34,15 +35,15 @@ import (
 
 func Convert(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl convert --filename=<FILENAME>
+  <BINARY_NAME> convert --filename=<FILENAME>
                 [--output=<OUTPUT>] [--ignore-validation]
 
 Examples:
   # Convert the contents of policy.yaml to v3 policy.
-  calicoctl convert -f ./policy.yaml -o yaml
+  <BINARY_NAME> convert -f ./policy.yaml -o yaml
 
   # Convert a policy based on the JSON passed into stdin.
-  cat policy.json | calicoctl convert -f -
+  cat policy.json | <BINARY_NAME> convert -f -
 
 Options:
   -h --help                     Show this screen.
@@ -58,6 +59,10 @@ Description:
 
   The default output will be printed to stdout in YAML format.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -23,19 +23,20 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 func Create(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl create --filename=<FILENAME> [--recursive] [--skip-empty]
+  <BINARY_NAME> create --filename=<FILENAME> [--recursive] [--skip-empty]
                    [--skip-exists] [--config=<CONFIG>] [--namespace=<NS>]
 
 Examples:
   # Create a policy using the data in policy.yaml.
-  calicoctl create -f ./policy.yaml
+  <BINARY_NAME> create -f ./policy.yaml
 
   # Create a policy based on the JSON passed into stdin.
-  cat policy.json | calicoctl create -f -
+  cat policy.json | <BINARY_NAME> create -f -
 
 Options:
   -h --help                 Show this screen.
@@ -87,6 +88,10 @@ Description:
   failure creating a specific resource it is possible to work out which
   resource failed based on the number of resources successfully created.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/datastore.go
+++ b/calicoctl/commands/datastore.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/datastore"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 // Datastore function is a switch to datastore related sub-commands
 func Datastore(args []string) error {
 	var err error
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl datastore <command> [<args>...]
+  <BINARY_NAME> datastore <command> [<args>...]
 
     migrate  Migrate the contents of an etcdv3 datastore to a Kubernetes datastore.
 
@@ -36,10 +37,14 @@ Options:
   -h --help      Show this screen.
 
 Description:
-  Datastore specific commands for calicoctl.
+  Datastore specific commands for <BINARY_NAME>.
 
-  See 'calicoctl datastore <command> --help' to read about a specific subcommand.
+  See '<BINARY_NAME> datastore <command> --help' to read about a specific subcommand.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	arguments, err := docopt.Parse(doc, args, true, "", true, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/datastore/migrate.go
+++ b/calicoctl/commands/datastore/migrate.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/datastore/migrate"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 // Migrate function is a switch to migrate related sub-commands
 func Migrate(args []string) error {
 	var err error
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl datastore migrate <command> [<args>...]
+  <BINARY_NAME> datastore migrate <command> [<args>...]
 
     export  Export the contents of the etcdv3 datastore to yaml.
     import  Store and convert yaml of resources into the Kubernetes datastore.
@@ -39,10 +40,14 @@ Options:
   -h --help      Show this screen.
 
 Description:
-  Migration specific commands for calicoctl.
+  Migration specific commands.
 
-  See 'calicoctl datastore migrate <command> --help' to read about a specific subcommand.
+  See '<BINARY_NAME> datastore migrate <command> --help' to read about a specific subcommand.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	arguments, err := docopt.Parse(doc, args, true, "", true, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/datastore/migrate/export.go
+++ b/calicoctl/commands/datastore/migrate/export.go
@@ -29,6 +29,7 @@ import (
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
@@ -78,7 +79,7 @@ var namespacedResources map[string]struct{} = map[string]struct{}{
 
 func Export(args []string) error {
 	doc := `Usage:
-  calicoctl datastore migrate export [--config=<CONFIG>]
+  <BINARY_NAME> datastore migrate export [--config=<CONFIG>]
 
 Options:
   -h --help                 Show this screen.
@@ -90,7 +91,7 @@ Description:
   Export the contents of the etcdv3 datastore.  Resources will be exported
   in yaml and json format. Save the results of this command to a file for
   later use with the import command.
-  
+
   The resources exported include the following:
     - IPAMBlocks
     - BlockAffinities
@@ -113,6 +114,9 @@ Description:
     - WorkloadEndpoints
     - Profiles
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {

--- a/calicoctl/commands/datastore/migrate/import.go
+++ b/calicoctl/commands/datastore/migrate/import.go
@@ -34,6 +34,7 @@ import (
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/crds"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 	yaml "github.com/projectcalico/go-yaml-wrapper"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	apiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
@@ -47,7 +48,7 @@ import (
 
 func Import(args []string) error {
 	doc := `Usage:
-  calicoctl datastore migrate import --filename=<FILENAME> [--config=<CONFIG>]
+  <BINARY_NAME> datastore migrate import --filename=<FILENAME> [--config=<CONFIG>]
 
 Options:
   -h --help                 Show this screen.
@@ -61,6 +62,9 @@ Description:
   Import the contents of the etcdv3 datastore from the file created by the
   export command.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {

--- a/calicoctl/commands/datastore/migrate/lock.go
+++ b/calicoctl/commands/datastore/migrate/lock.go
@@ -23,13 +23,14 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 	"github.com/projectcalico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/libcalico-go/lib/options"
 )
 
 func Lock(args []string) error {
 	doc := `Usage:
-  calicoctl datastore migrate lock [--config=<CONFIG>]
+  <BINARY_NAME> datastore migrate lock [--config=<CONFIG>]
 
 Options:
   -h --help                 Show this screen.
@@ -42,6 +43,9 @@ Description:
   Calico resources from affecting the cluster but does not prevent updating
   or creating new Calico resources.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {

--- a/calicoctl/commands/datastore/migrate/unlock.go
+++ b/calicoctl/commands/datastore/migrate/unlock.go
@@ -23,12 +23,13 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 	"github.com/projectcalico/libcalico-go/lib/options"
 )
 
 func Unlock(args []string) error {
 	doc := `Usage:
-  calicoctl datastore migrate unlock [--config=<CONFIG>]
+  <BINARY_NAME> datastore migrate unlock [--config=<CONFIG>]
 
 Options:
   -h --help                 Show this screen.
@@ -40,6 +41,9 @@ Description:
   Unlock the datastore to complete migration. This once again allows
   Calico resources to take effect in the cluster.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -23,23 +23,24 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 func Delete(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl delete ( (<KIND> [<NAME>...]) |
+  <BINARY_NAME> delete ( (<KIND> [<NAME>...]) |
                    --filename=<FILE> [--recursive] [--skip-empty] )
                    [--skip-not-exists] [--config=<CONFIG>] [--namespace=<NS>]
 
 Examples:
   # Delete a policy using the type and name specified in policy.yaml.
-  calicoctl delete -f ./policy.yaml
+  <BINARY_NAME> delete -f ./policy.yaml
 
   # Delete a policy based on the type and name in the YAML passed into stdin.
-  cat policy.yaml | calicoctl delete -f -
+  cat policy.yaml | <BINARY_NAME> delete -f -
 
   # Delete policies with names "foo" and "bar"
-  calicoctl delete policy foo bar
+  <BINARY_NAME> delete policy foo bar
 
 Options:
   -h --help                 Show this screen.
@@ -99,6 +100,10 @@ Description:
   failure deleting a specific resource it is possible to work out which
   resource failed based on the number of resources successfully deleted.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -25,20 +25,21 @@ import (
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 func Get(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl get ( (<KIND> [<NAME>...]) |
+  <BINARY_NAME> get ( (<KIND> [<NAME>...]) |
                 --filename=<FILENAME> [--recursive] [--skip-empty] )
                 [--output=<OUTPUT>] [--config=<CONFIG>] [--namespace=<NS>] [--all-namespaces] [--export]
 
 Examples:
   # List all policy in default output format.
-  calicoctl get policy
+  <BINARY_NAME> get policy
 
   # List specific policies in YAML format
-  calicoctl get -o yaml policy my-policy-1 my-policy-2
+  <BINARY_NAME> get -o yaml policy my-policy-1 my-policy-2
 
 Options:
   -h --help                    Show this screen.
@@ -118,6 +119,10 @@ Description:
   for the golang template definitions) and the valid column names (required for
   the custom-columns option).
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/ipam.go
+++ b/calicoctl/commands/ipam.go
@@ -22,26 +22,31 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/ipam"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 // IPAM takes keyword with an IP address then calls the subcommands.
 func IPAM(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl ipam <command> [<args>...]
+  <BINARY_NAME> ipam <command> [<args>...]
 
     release          Release a Calico assigned IP address.
     show             Show details of a Calico configuration,
                      assigned IP address, or of overall IP usage.
-    configure        Configure IPAM        
+    configure        Configure IPAM
 
 Options:
   -h --help      Show this screen.
 
 Description:
-  IP Address Management specific commands for calicoctl.
+  IP address management commands for Calico.
 
-  See 'calicoctl ipam <command> --help' to read about a specific subcommand.
+  See '<BINARY_NAME> ipam <command> --help' to read about a specific subcommand.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	arguments, err := docopt.Parse(doc, args, true, "", true, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/ipam/configure.go
+++ b/calicoctl/commands/ipam/configure.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 	"github.com/projectcalico/libcalico-go/lib/ipam"
 )
 
@@ -50,7 +51,7 @@ func updateIPAMStrictAffinity(ctx context.Context, ipamClient ipam.Interface, en
 // Configure IPAM.
 func Configure(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl ipam configure --strictaffinity=<true/false> [--config=<CONFIG>]
+  <BINARY_NAME> ipam configure --strictaffinity=<true/false> [--config=<CONFIG>]
 
 Options:
   -h --help                        Show this screen.
@@ -63,6 +64,10 @@ Options:
 Description:
  Modify configuration for Calico IP address management.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/ipam/release.go
+++ b/calicoctl/commands/ipam/release.go
@@ -26,12 +26,13 @@ import (
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 // IPAM takes keyword with an IP address then calls the subcommands.
 func Release(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl ipam release --ip=<IP> [--config=<CONFIG>]
+  <BINARY_NAME> ipam release --ip=<IP> [--config=<CONFIG>]
 
 Options:
   -h --help             Show this screen.
@@ -49,6 +50,10 @@ Description:
   using it, so only use this command to clean up addresses from endpoints that
   were not cleanly removed from Calico.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/ipam/show.go
+++ b/calicoctl/commands/ipam/show.go
@@ -25,6 +25,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/clientv3"
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
@@ -244,7 +245,7 @@ func showConfiguration(ctx context.Context, ipamClient ipam.Interface) error {
 // IPAM takes keyword with an IP address then calls the subcommands.
 func Show(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl ipam show [--ip=<IP> | --show-blocks | --show-borrowed | --show-configuration] [--config=<CONFIG>]
+  <BINARY_NAME> ipam show [--ip=<IP> | --show-blocks | --show-borrowed | --show-configuration] [--config=<CONFIG>]
 
 Options:
   -h --help                Show this screen.
@@ -260,6 +261,10 @@ Description:
   The ipam show command prints information about a given IP address, or about
   overall IP usage.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/label.go
+++ b/calicoctl/commands/label.go
@@ -23,29 +23,30 @@ import (
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/resourcemgr"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 
 	log "github.com/sirupsen/logrus"
 )
 
 func Label(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl label (<KIND> <NAME> 
+  <BINARY_NAME> label (<KIND> <NAME>
   	              ( <key>=<value> [--overwrite] |
   	                <key> --remove )
                   [--config=<CONFIG>] [--namespace=<NS>])
-                  
+
 
 
 
 Examples:
   # Label a workload endpoint
-  calicoctl label workloadendpoints nginx --namespace=default app=web
+  <BINARY_NAME> label workloadendpoints nginx --namespace=default app=web
 
   # Label a node and overwrite the original value of key 'cluster'
-  calicoctl label nodes node1 cluster=frontend --overwrite
+  <BINARY_NAME> label nodes node1 cluster=frontend --overwrite
 
   # Remove label with key 'cluster' of the node
-  calicoctl label nodes node1 cluster --remove
+  <BINARY_NAME> label nodes node1 cluster --remove
 
 Options:
   -h --help                    Show this screen.
@@ -88,8 +89,11 @@ Description:
 
   When labeling a resource on an existing key:
   - gets an error if option --overwrite is not provided.
-  - value of the key updates to specified value if option --overwrite is provided. 
+  - value of the key updates to specified value if option --overwrite is provided.
   `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	binaryName, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", binaryName)
 
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {

--- a/calicoctl/commands/node/checksystem.go
+++ b/calicoctl/commands/node/checksystem.go
@@ -25,6 +25,7 @@ import (
 
 	docopt "github.com/docopt/docopt-go"
 	goversion "github.com/mcuadros/go-version"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -38,8 +39,8 @@ var requiredModules = []string{"ip_set", "ip_tables", "ip6_tables", "ipt_REJECT"
 
 // Checksystem checks host system for compatible versions
 func Checksystem(args []string) error {
-	doc := `Usage: 
-  calicoctl node checksystem
+	doc := `Usage:
+  <BINARY_NAME> node checksystem
 
 Options:
   -h --help                 Show this screen.
@@ -47,6 +48,9 @@ Options:
 Description:
   Check the compatibility of this compute host to run a Calico node instance.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {

--- a/calicoctl/commands/node/diags.go
+++ b/calicoctl/commands/node/diags.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/docopt/docopt-go"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 	log "github.com/sirupsen/logrus"
 	shutil "github.com/termie/go-shutil"
 )
@@ -41,7 +42,7 @@ type diagCmd struct {
 func Diags(args []string) error {
 	var err error
 	doc := `Usage:
-  calicoctl node diags [--log-dir=<LOG_DIR>]
+  <BINARY_NAME> node diags [--log-dir=<LOG_DIR>]
 
 Options:
   -h --help               Show this screen.
@@ -60,6 +61,9 @@ Description:
   This command must be run on the specific Calico node that you are gathering
   diagnostics for.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	arguments, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {

--- a/calicoctl/commands/node/run.go
+++ b/calicoctl/commands/node/run.go
@@ -31,6 +31,7 @@ import (
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	"github.com/projectcalico/libcalico-go/lib/names"
 	"github.com/projectcalico/libcalico-go/lib/net"
@@ -56,7 +57,7 @@ var (
 func Run(args []string) error {
 	var err error
 	doc := `Usage:
-  calicoctl node run [--ip=<IP>] [--ip6=<IP6>] [--as=<AS_NUM>]
+  <BINARY_NAME> node run [--ip=<IP>] [--ip6=<IP6>] [--as=<AS_NUM>]
                      [--name=<NAME>]
                      [--ip-autodetection-method=<IP_AUTODETECTION_METHOD>]
                      [--ip6-autodetection-method=<IP6_AUTODETECTION_METHOD>]
@@ -77,7 +78,6 @@ Options:
                            will use the value configured on the node resource.
                            If there is no configured value and --as option is
                            omitted, the node will inherit the global AS number
-                           (see 'calicoctl config' for details).
      --ip=<IP>             Set the local IPv4 routing address for this node.
                            If omitted, it will use the value configured on the
                            node resource.  If there is no configured value
@@ -151,6 +151,10 @@ Description:
   This command is used to start a calico/node container instance which provides
   Calico networking and network policy on your compute host.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	binaryName, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", binaryName)
+
 	arguments, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		log.Info(err)

--- a/calicoctl/commands/node/status.go
+++ b/calicoctl/commands/node/status.go
@@ -30,6 +30,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	gobgp "github.com/osrg/gobgp/client"
 	"github.com/osrg/gobgp/packet/bgp"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 	"github.com/shirou/gopsutil/process"
 	log "github.com/sirupsen/logrus"
 )
@@ -37,7 +38,7 @@ import (
 // Status prints status of the node and returns error (if any)
 func Status(args []string) error {
 	doc := `Usage:
-  calicoctl node status
+  <BINARY_NAME> node status
 
 Options:
   -h --help                 Show this screen.
@@ -46,6 +47,9 @@ Description:
   Check the status of the Calico node instance.  This includes the status and
   uptime of the node instance, and BGP peering states.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {

--- a/calicoctl/commands/node_linux.go
+++ b/calicoctl/commands/node_linux.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/node"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 // Node function is a switch to node related sub-commands
 func Node(args []string) error {
 	var err error
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl node <command> [<args>...]
+  <BINARY_NAME> node <command> [<args>...]
 
     run          Run the Calico node container image.
     status       View the current status of a Calico node.
@@ -39,11 +40,15 @@ Options:
   -h --help      Show this screen.
 
 Description:
-  Node specific commands for calicoctl.  These commands must be run directly on
+  Node specific commands for <BINARY_NAME>.  These commands must be run directly on
   the compute host running the Calico node instance.
 
-  See 'calicoctl node <command> --help' to read about a specific subcommand.
+  See '<BINARY_NAME> node <command> --help' to read about a specific subcommand.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	arguments, err := docopt.Parse(doc, args, true, "", true, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/patch.go
+++ b/calicoctl/commands/patch.go
@@ -23,18 +23,19 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 func Patch(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl patch <KIND> <NAME> --patch=<PATCH> [--type=<TYPE>] [--config=<CONFIG>] [--namespace=<NS>]
+  <BINARY_NAME> patch <KIND> <NAME> --patch=<PATCH> [--type=<TYPE>] [--config=<CONFIG>] [--namespace=<NS>]
 
 Examples:
   # Partially update a node using a strategic merge patch.
-  calicoctl patch node node-0 --patch '{"spec":{"bgp": {"routeReflectorClusterID": "CLUSTER_ID"}}}'
+  <BINARY_NAME> patch node node-0 --patch '{"spec":{"bgp": {"routeReflectorClusterID": "CLUSTER_ID"}}}'
 
   # Partially update a node using a json merge patch.
-  calicoctl patch node node-0 --patch '{"spec":{"bgp": {"routeReflectorClusterID": "CLUSTER_ID"}}}' --type json
+  <BINARY_NAME> patch node node-0 --patch '{"spec":{"bgp": {"routeReflectorClusterID": "CLUSTER_ID"}}}' --type json
 
 Options:
   -h --help                  Show this screen.
@@ -80,6 +81,10 @@ Description:
   time.  The name is required along with any and other identifiers required to
   uniquely identify a resource of the specified type.
 `
+
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
 
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -25,19 +25,20 @@ import (
 
 	"github.com/projectcalico/calicoctl/calicoctl/commands/common"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 func Replace(args []string) error {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl replace --filename=<FILENAME> [--recursive] [--skip-empty]
+  <BINARY_NAME> replace --filename=<FILENAME> [--recursive] [--skip-empty]
                     [--config=<CONFIG>] [--namespace=<NS>]
 
 Examples:
   # Replace a policy using the data in policy.yaml.
-  calicoctl replace -f ./policy.yaml
+  <BINARY_NAME> replace -f ./policy.yaml
 
   # Replace a policy based on the JSON passed into stdin.
-  cat policy.json | calicoctl replace -f -
+  cat policy.json | <BINARY_NAME> replace -f -
 
 Options:
   -h --help                  Show this screen.
@@ -88,6 +89,10 @@ Description:
   When replacing a resource, the complete resource spec must be provided, it is
   not sufficient to supply only the fields that are being updated.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -29,30 +29,36 @@ import (
 	"github.com/projectcalico/calicoctl/calicoctl/commands/argutils"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calicoctl/calicoctl/commands/constants"
+	"github.com/projectcalico/calicoctl/calicoctl/util"
 )
 
 var VERSION, GIT_REVISION string
 var VERSION_SUMMARY string
 
 func init() {
-	VERSION_SUMMARY = `Run 'calicoctl version' to see version information.`
+	name, _ := util.NameAndDescription()
+	VERSION_SUMMARY = strings.ReplaceAll(`Run '<BINARY_NAME> version' to see version information.`, "<BINARY_NAME>", name)
 }
 
 func Version(args []string) error {
 	doc := `Usage:
-  calicoctl version [--config=<CONFIG>] [--poll=<POLL>]
+  <BINARY_NAME> version [--config=<CONFIG>] [--poll=<POLL>]
 
 Options:
   -h --help             Show this screen.
   -c --config=<CONFIG>  Path to the file containing connection configuration in
                         YAML or JSON format.
                         [default: ` + constants.DefaultConfigPath + `]
-     --poll=<POLL>      Poll for changes to the cluster information at a frequency specified using POLL duration 
-                        (e.g. 1s, 10m, 2h etc.). A value of 0 (the default) disables polling.  
+     --poll=<POLL>      Poll for changes to the cluster information at a frequency specified using POLL duration
+                        (e.g. 1s, 10m, 2h etc.). A value of 0 (the default) disables polling.
 
 Description:
-  Display the version of calicoctl.
+  Display the version of <BINARY_NAME>.
 `
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		return fmt.Errorf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.", strings.Join(args, " "))

--- a/calicoctl/util/docstring.go
+++ b/calicoctl/util/docstring.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func NameAndDescription() (string, string) {
+	// Determine name to use in docstring. We want the docstring to change if
+	// we're running as a kubectl plugin.
+	name := "calicoctl"
+	desc := "calicoctl command line tool"
+	if strings.HasPrefix(filepath.Base(os.Args[0]), "kubectl-") {
+		// We're a kubectl plugin
+		name = "kubectl-calico"
+		desc = "calico kubectl plugin"
+	}
+	return name, desc
+}

--- a/tests/st/calicoctl/test_flags.py
+++ b/tests/st/calicoctl/test_flags.py
@@ -33,8 +33,8 @@ class TestCalicoctlCLIFlags(TestBase):
         """
         # no -m flag
         rc = calicoctl("-m")
-        rc.assert_error(text="Invalid option: 'calicoctl -m'.")
+        rc.assert_error(text="Invalid option: '-m'.")
         # no --unknown-flag flag
         rc = calicoctl("--unknown-flag")
-        rc.assert_error(text="Invalid option: 'calicoctl --unknown-flag'.")
+        rc.assert_error(text="Invalid option: '--unknown-flag'.")
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

When running as a kubectl plugin, we need to change the name of the
binary that appears in our docstrings to say `kubectl-calico` instead of
`calicoctl`.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```