### PR TITLE
calicoctl get -A option support 

### DIFF
--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -60,7 +60,7 @@ Options:
   -n --namespace=<NS>          Namespace of the resource.
                                Only applicable to NetworkPolicy, NetworkSet, and WorkloadEndpoint.
                                Uses the default namespace if not specified.
-  -a --all-namespaces          If present, list the requested object(s) across all namespaces.
+  -A --all-namespaces          If present, list the requested object(s) across all namespaces.
   --export                     If present, returns the requested object(s) stripped of
                                cluster-specific information. This flag will be ignored
                                if <NAME> is not specified.
@@ -124,6 +124,13 @@ Description:
 	// Replace all instances of BINARY_NAME with the name of the binary.
 	name, _ := util.NameAndDescription()
 	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
+	// -a option Backward compatibility
+	for k, v := range args {
+		if v == "-a" {
+			args[k] = "-A"
+		}
+	}
 
 	parsedArgs, err := docopt.ParseArgs(doc, args, "")
 	if err != nil {

--- a/tests/fv/namespace_option_test.go
+++ b/tests/fv/namespace_option_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2019 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_test
+
+import (
+	"context"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+	"testing"
+
+	. "github.com/projectcalico/calicoctl/v3/tests/fv/utils"
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/logutils"
+	"github.com/projectcalico/libcalico-go/lib/options"
+)
+
+func init() {
+	log.AddHook(logutils.ContextHook{})
+	log.SetFormatter(&logutils.Formatter{})
+}
+
+func TestMultiOption(t *testing.T) {
+	RegisterTestingT(t)
+
+	ctx := context.Background()
+
+	// Create a Calico client.
+	config := apiconfig.NewCalicoAPIConfig()
+	config.Spec.DatastoreType = "etcdv3"
+	config.Spec.EtcdEndpoints = "http://127.0.0.1:2379"
+	client, err := clientv3.New(*config)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Create an IPv4 pool.
+	pool := v3.NewIPPool()
+	pool.Name = "ipam-test-v4"
+	pool.Spec.CIDR = "10.65.0.0/16"
+	_, err = client.IPPools().Create(ctx, pool, options.SetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	np := v3.NewNetworkPolicy()
+	np.Name = "policy1"
+	np.Namespace = "firstns"
+	_, err = client.NetworkPolicies().Create(ctx, np, options.SetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	np.Name = "policy2"
+	np.Namespace = "secondns"
+	_, err = client.NetworkPolicies().Create(ctx, np, options.SetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	out, err := CalicoctlMayFail(false, "get", "ippool", "-A")
+	Expect(err).To(HaveOccurred())
+	Expect(out).To(Equal("IPPool is not namespaced\n"))
+
+	out, err = CalicoctlMayFail(false, "get", "ippool", "-a")
+	Expect(err).To(HaveOccurred())
+	Expect(out).To(Equal("IPPool is not namespaced\n"))
+
+	out = Calicoctl(false, "get", "networkPolicy", "-A")
+	Expect(out).To(Equal("NAMESPACE   NAME      \nfirstns     policy1   \nsecondns    policy2   \n\n"))
+
+	out = Calicoctl(false, "get", "networkPolicy", "-a")
+	Expect(out).To(Equal("NAMESPACE   NAME      \nfirstns     policy1   \nsecondns    policy2   \n\n"))
+
+}


### PR DESCRIPTION
This PR changes `-a` option to `-A` in docs it also adds backward compatibility for `-a`.

```release-note
Introduces new `-A` option to calicoctl and deprecates the earlier `-a` flag, which will be removed in a subsequent release.
```
@caseydavenport 