### PR TITLE
Add tests for projectcalico/libcalico-go#1361

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ LOCAL_BUILD_DEP:=set-up-local-build
 EXTRA_DOCKER_ARGS+=-v $(CURDIR)/../libcalico-go:/go/src/github.com/projectcalico/libcalico-go:rw
 $(LOCAL_BUILD_DEP):
 	$(DOCKER_RUN) $(CALICO_BUILD) go mod edit -replace=github.com/projectcalico/libcalico-go=../libcalico-go
-	$(DOCKER_RUN) $(CALICO_BUILD) go mod vendor
 endif
 
 include Makefile.common

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ GO_BUILD_VER=v0.49
 
 SEMAPHORE_PROJECT_ID?=$(SEMAPHORE_CALICOCTL_PROJECT_ID)
 
+KUBE_MASTER_PORT?=8080
+KUBE_MOCK_NODE_MANIFEST?=mock-node.yaml
+
 ###############################################################################
 # Download and include Makefile.common
 #   Additions to EXTRA_DOCKER_ARGS need to happen before the include since
@@ -27,6 +30,7 @@ LOCAL_BUILD_DEP:=set-up-local-build
 EXTRA_DOCKER_ARGS+=-v $(CURDIR)/../libcalico-go:/go/src/github.com/projectcalico/libcalico-go:rw
 $(LOCAL_BUILD_DEP):
 	$(DOCKER_RUN) $(CALICO_BUILD) go mod edit -replace=github.com/projectcalico/libcalico-go=../libcalico-go
+	$(DOCKER_RUN) $(CALICO_BUILD) go mod vendor
 endif
 
 include Makefile.common
@@ -216,10 +220,12 @@ ut: $(LOCAL_BUILD_DEP) bin/calicoctl-linux-amd64
 ## Run the tests in a container. Useful for CI, Mac dev.
 fv: $(LOCAL_BUILD_DEP) bin/calicoctl-linux-amd64
 	$(MAKE) run-etcd-host
-	$(MAKE) run-kubernetes-master
+	$(MAKE) run-kubernetes-master KUBE_MASTER_PORT=8080 KUBE_MOCK_NODE_MANIFEST=mock-node.yaml
+	$(MAKE) run-kubernetes-master KUBE_MASTER_PORT=8082 KUBE_MOCK_NODE_MANIFEST=mock-node-second.yaml
 	$(DOCKER_RUN) $(CALICO_BUILD) sh -c 'cd /go/src/$(PACKAGE_NAME) && go test ./tests/fv'
 	$(MAKE) stop-etcd
-	$(MAKE) stop-kubernetes-master
+	$(MAKE) stop-kubernetes-master KUBE_MASTER_PORT=8080
+	$(MAKE) stop-kubernetes-master KUBE_MASTER_PORT=8082
 
 ###############################################################################
 # STs
@@ -280,11 +286,13 @@ stop-etcd:
 run-kubernetes-master: stop-kubernetes-master
 	# Run a Kubernetes apiserver using Docker.
 	docker run \
-		--net=host --name st-apiserver \
+		--net=host --name st-apiserver-${KUBE_MASTER_PORT} \
 		--detach \
 		gcr.io/google_containers/hyperkube-amd64:${K8S_VERSION} kube-apiserver \
 			--bind-address=0.0.0.0 \
+			--secure-port=1${KUBE_MASTER_PORT} \
 			--insecure-bind-address=0.0.0.0 \
+			--port=${KUBE_MASTER_PORT} \
 	        	--etcd-servers=http://127.0.0.1:2379 \
 			--admission-control=NamespaceLifecycle,LimitRanger,DefaultStorageClass,ResourceQuota \
 			--service-cluster-ip-range=10.101.0.0/16 \
@@ -292,43 +300,44 @@ run-kubernetes-master: stop-kubernetes-master
 			--logtostderr=true
 
 	# Wait until the apiserver is accepting requests.
-	while ! docker exec st-apiserver kubectl get nodes; do echo "Waiting for apiserver to come up..."; sleep 2; done
+	while ! docker exec st-apiserver-${KUBE_MASTER_PORT} kubectl get nodes; do echo "Waiting for apiserver to come up..."; sleep 2; done
 
 	# And run the controller manager.
 	docker run \
-		--net=host --name st-controller-manager \
+		--net=host --name st-controller-manager-${KUBE_MASTER_PORT} \
 		--detach \
 		gcr.io/google_containers/hyperkube-amd64:${K8S_VERSION} kube-controller-manager \
-                        --master=127.0.0.1:8080 \
+                        --master=127.0.0.1:${KUBE_MASTER_PORT} \
                         --min-resync-period=3m \
                         --allocate-node-cidrs=true \
                         --cluster-cidr=10.10.0.0/16 \
                         --v=5
 
 	# Create a Node in the API for the tests to use.
-	docker run \
+	while ! docker run \
 	    --net=host \
 	    --rm \
-		-v  $(CURDIR):/manifests \
+		-v $(CURDIR):/manifests \
 		gcr.io/google_containers/hyperkube-amd64:${K8S_VERSION} kubectl \
-		--server=http://127.0.0.1:8080 \
-		apply -f /manifests/tests/st/manifests/mock-node.yaml
+		--server=http://127.0.0.1:${KUBE_MASTER_PORT} \
+		apply -f /manifests/tests/st/manifests/${KUBE_MOCK_NODE_MANIFEST}; \
+		do echo "Waiting for node to apply successfully..."; sleep 2; done
 
 	# Create a namespace in the API for the tests to use.
-	docker run \
+	-docker run \
 	    --net=host \
 	    --rm \
 		gcr.io/google_containers/hyperkube-amd64:${K8S_VERSION} kubectl \
-		--server=http://127.0.0.1:8080 \
+		--server=http://127.0.0.1:${KUBE_MASTER_PORT} \
 		create namespace test
 	
 ## Stop the local kubernetes master
 stop-kubernetes-master:
 	# Delete the cluster role binding.
-	-docker exec st-apiserver kubectl delete clusterrolebinding anonymous-admin
+	-docker exec st-apiserver-${KUBE_MASTER_PORT} kubectl delete clusterrolebinding anonymous-admin
 
 	# Stop master components.
-	-docker rm -f st-apiserver st-controller-manager
+	-docker rm -f st-apiserver-${KUBE_MASTER_PORT} st-controller-manager-${KUBE_MASTER_PORT}
 
 ###############################################################################
 # CI

--- a/test-data/kubectl-config-second.yaml
+++ b/test-data/kubectl-config-second.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: 127.0.0.1:8082
+  name: secondary-cluster
+contexts:
+- context:
+    cluster: secondary-cluster
+    user: default
+  name: second
+current-context: ""
+kind: Config
+preferences: {}
+users: null

--- a/tests/fv/multi_context_test.go
+++ b/tests/fv/multi_context_test.go
@@ -15,9 +15,11 @@
 package fv_test
 
 import (
-	log "github.com/sirupsen/logrus"
 	"os"
+	"strings"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 
 	. "github.com/onsi/gomega"
 	. "github.com/projectcalico/calicoctl/v3/tests/fv/utils"
@@ -32,7 +34,10 @@ func init() {
 func TestMultiCluster(t *testing.T) {
 	RegisterTestingT(t)
 
-	os.Setenv("KUBECONFIG", "/go/src/github.com/projectcalico/calicoctl/test-data/kubectl-config.yaml")
+	os.Setenv("KUBECONFIG", strings.Join([]string{
+		"/go/src/github.com/projectcalico/calicoctl/test-data/kubectl-config.yaml",
+		"/go/src/github.com/projectcalico/calicoctl/test-data/kubectl-config-second.yaml",
+	}, ":"))
 
 	// This check will Fail, kubectl-config.yaml file that we are using for this only contains "main" context.
 	out, err := CalicoctlMayFail(true, "get", "node", "--context", "fake")
@@ -42,6 +47,9 @@ func TestMultiCluster(t *testing.T) {
 	// This check should Pass
 	out = Calicoctl(true, "get", "node", "--context", "main")
 	Expect(out).To(ContainSubstring("node4"))
+
+	out = Calicoctl(true, "get", "node", "--context", "second")
+	Expect(out).To(ContainSubstring("node8"))
 
 	// This check should Pass proving --context works regardless of its position
 	out = Calicoctl(true, "--context", "main", "get", "node")

--- a/tests/st/manifests/mock-node-second.yaml
+++ b/tests/st/manifests/mock-node-second.yaml
@@ -1,0 +1,14 @@
+# This is a Node used by the k8s ST tests.  The migration tests
+# rely on this Node exising in the Kubernetes API.
+kind: Node
+apiVersion: v1
+metadata:
+  name: "node8"
+spec:
+  podCIDR: "10.10.20.0/24"
+status:
+  addresses:
+  - type: NodeInternalIP
+    address: "127.0.0.1/32"
+  - type: NodeExternalIP
+    address: "8.7.6.5/32"

--- a/tests/st/manifests/mock-node-second.yaml
+++ b/tests/st/manifests/mock-node-second.yaml
@@ -1,5 +1,3 @@
-# This is a Node used by the k8s ST tests.  The migration tests
-# rely on this Node exising in the Kubernetes API.
 kind: Node
 apiVersion: v1
 metadata:


### PR DESCRIPTION
- `make fv` now starts two apiservers (:8080, :8082) with two nodes (node4, node8 respectively)
- test scenario described in projectcalico/calico#4312
	- e.g. `KUBECONFIG=~/.kube/config:~/.kube/kubeconfig_2 calicoctl version`
- fix LOCAL_BUILD: run `go mod vendor` after `go mod edit` so that the replace directive gets synched to `vendor/modules.txt` when using your local ../libcalico-go repo

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [x] Tests
- [x] Documentation
- [X] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
`calicoctl` now supports multiple kubeconfig files via KUBECONFIG env var, just as `kubectl` would:

Example  usage:

    export KUBECONFIG=~/.kube/config:~/.kube/kubeconfig_2
    
    calicoctl get node
    calicoctl --context config2 get node
```
