### PR TITLE
Add client/cluster version mismatch verification

### DIFF
--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -130,3 +130,102 @@ Description:
 
 	return err
 }
+
+func VersionMismatch(args []string) error {
+	// We need to "look ahead" to see if config or context have been passed in the args
+	doc := `Usage:
+  <BINARY_NAME> [options] [<args>...]
+
+Options:
+  -h --help                 Show this screen.
+  -c --config=<config>      Path to the file containing connection
+                            configuration in YAML or JSON format.
+                            [default: ` + constants.DefaultConfigPath + `]
+  --context=<context>       The name of the kubeconfig context to use.
+  -a
+  -A --all-namespaces
+     --as=<AS_NUM>
+     --backend=(bird|gobgp|none)
+     --dryrun
+     --export
+     --felix-config=<CONFIG>
+  -f --filename=<FILENAME>
+     --force
+     --from-report=<REPORT>
+     --ignore-validation
+     --init-system
+     --ip6-autodetection-method=<IP6_AUTODETECTION_METHOD>
+     --ip6=<IP6>
+     --ip-autodetection-method=<IP_AUTODETECTION_METHOD>
+     --ip=<IP>
+     --kernel-config=<kernel-config>
+     --log-dir=<LOG_DIR>
+     --name=<NAME>
+  -n --namespace=<NS>
+     --no-default-ippools
+     --node-image=<DOCKER_IMAGE_NAME>
+  -o --output=<OUTPUT FORMAT>
+     --overwrite
+     --poll=<POLL>
+  -p --patch=<PATCH>
+     --remove
+  -R --recursive
+     --show-all-ips
+     --show-blocks
+     --show-borrowed
+     --show-configuration
+     --show-problem-ips
+     --skip-empty
+     --skip-exists
+  -s --skip-not-exists
+     --strictaffinity=<true/false>
+  -t --type=<TYPE>
+
+Description:
+  This is an intermediate parser for version mismatch verification and should
+  contain every command line option used everywhere in <BINARY_NAME>. If there
+  is an error at this point, there probably is some command line option that
+  should be added to this docstring.
+`
+	// Replace all instances of BINARY_NAME with the name of the binary.
+	name, _ := util.NameAndDescription()
+	doc = strings.ReplaceAll(doc, "<BINARY_NAME>", name)
+
+	parsedArgs, err := docopt.ParseArgs(doc, args, "")
+	if err != nil {
+		return fmt.Errorf("docopts parsing for version mismatch verification error: %w", err)
+	}
+
+	if context := parsedArgs["--context"]; context != nil {
+		os.Setenv("K8S_CURRENT_CONTEXT", context.(string))
+	}
+
+	cf, _ := parsedArgs["--config"].(string)
+
+	client, err := clientmgr.NewClient(cf)
+	if err != nil {
+		return fmt.Errorf("Unable to create Calico API client to verify version mismatch: %w", err)
+	}
+
+	ctx := context.Background()
+
+	ci, err := client.ClusterInformation().Get(ctx, "default", options.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("Unable to get Cluster Information to verify version mismatch: %w", err)
+	}
+
+	clusterv := ci.Spec.CalicoVersion
+	if clusterv == "" {
+		clusterv = "unknown"
+	} else {
+		clusterv = strings.Split(clusterv, "-")[0]
+	}
+
+	clientv := strings.Split(VERSION, "-")[0]
+
+	if clusterv != clientv {
+		return fmt.Errorf("Version mismatch.\nClient Version:   %s\nCluster Version:  %s", VERSION, clusterv)
+	}
+
+	return nil
+}

--- a/tests/fv/helper/calico_version_helper.go
+++ b/tests/fv/helper/calico_version_helper.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/docopt/docopt-go"
+	clientv3 "github.com/projectcalico/libcalico-go/lib/clientv3"
+
+	"github.com/projectcalico/calicoctl/v3/calicoctl/commands/clientmgr"
+	"github.com/projectcalico/calicoctl/v3/calicoctl/commands/constants"
+)
+
+var VERSION string
+
+func main() {
+	doc := `Usage:
+  calico_version_helper [options]
+
+Options:
+  -h --help                 Show this screen.
+  -v --version=<version>    Version to set.
+                            [default: ` + VERSION + `]
+  -c --config=<config>      Path to the file containing connection
+                            configuration in YAML or JSON format.
+                            [default: ` + constants.DefaultConfigPath + `]
+  --context=<context>       The name of the kubeconfig context to use.
+
+Description:
+  Set CalicoVersion in ClusterInformation.
+`
+	parsedArgs, err := docopt.ParseDoc(doc)
+	if err != nil {
+		fmt.Printf("Could not parse arguments: %s, err: %v\n", strings.Join(os.Args[1:], " "), err)
+		os.Exit(1)
+	}
+
+	if context := parsedArgs["--context"]; context != nil {
+		os.Setenv("K8S_CURRENT_CONTEXT", context.(string))
+	}
+
+	cf, _ := parsedArgs["--config"].(string)
+
+	cfg, err := clientmgr.LoadClientConfig(cf)
+	if err != nil {
+		fmt.Printf("Could not load client config: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Get the backend client for updating cluster info and migrating IPAM.
+	client, err := clientv3.New(*cfg)
+	if err != nil {
+		fmt.Printf("Could not create client: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	calicoVersion, _ := parsedArgs["--version"].(string)
+
+	if err := client.EnsureInitialized(ctx, calicoVersion, ""); err != nil {
+		fmt.Printf("Could not set calico version to %s: %v\n", calicoVersion, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Calico version set to %s\n", calicoVersion)
+}

--- a/tests/fv/ipam_test.go
+++ b/tests/fv/ipam_test.go
@@ -75,8 +75,13 @@ func TestIPAM(t *testing.T) {
 	_, err = client.Nodes().Create(ctx, node, options.SetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
+	// Set Calico version in ClusterInformation
+	out, err := SetCalicoVersion(false)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(out).To(ContainSubstring("Calico version set to"))
+
 	// ipam show with specific unallocated IP.
-	out := Calicoctl(false, "ipam", "show", "--ip=10.65.0.2")
+	out = Calicoctl(false, "ipam", "show", "--ip=10.65.0.2")
 	Expect(out).To(ContainSubstring("10.65.0.2 is not assigned"))
 
 	// ipam show, with no allocations yet.

--- a/tests/fv/migrate_ipam_test.go
+++ b/tests/fv/migrate_ipam_test.go
@@ -27,9 +27,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	. "github.com/projectcalico/calicoctl/v3/tests/fv/utils"
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
-	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
 	libapiv3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	"github.com/projectcalico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/libcalico-go/lib/ipam"
@@ -109,9 +109,14 @@ func TestDatastoreMigrationIPAM(t *testing.T) {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	// Set Calico version in ClusterInformation in etcd
+	out, err := SetCalicoVersion(false)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(out).To(ContainSubstring("Calico version set to"))
+
 	// Migrate the data
 	// Lock the etcd datastore
-	out := Calicoctl(false, "datastore", "migrate", "lock")
+	out = Calicoctl(false, "datastore", "migrate", "lock")
 	Expect(out).To(Equal("Datastore locked.\n"))
 
 	// Export the data

--- a/tests/fv/multi_context_test.go
+++ b/tests/fv/multi_context_test.go
@@ -40,10 +40,24 @@ func TestMultiCluster(t *testing.T) {
 		"/go/src/github.com/projectcalico/calicoctl/test-data/kubectl-config-second.yaml",
 	}, ":"))
 
+	// Set Calico version in ClusterInformation for both contexts
+	out, err := SetCalicoVersion(true, "--context", "main")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(out).To(ContainSubstring("Calico version set to"))
+
+	out, err = SetCalicoVersion(true, "--context", "second")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(out).To(ContainSubstring("Calico version set to"))
+
 	// This check will Fail, kubectl-config.yaml file that we are using for this only contains "main" context.
-	out, err := CalicoctlMayFail(true, "get", "node", "--context", "fake")
+	out, err = CalicoctlMayFail(true, "--allow-version-mismatch", "get", "node", "--context", "fake")
 	Expect(err).To(HaveOccurred())
 	Expect(out).To(ContainSubstring("Failed"))
+
+	// This check will Fail a version mismatch cannot be verified for context "fake"
+	out, err = CalicoctlMayFail(true, "get", "node", "--context", "fake")
+	Expect(err).To(HaveOccurred())
+	Expect(out).To(ContainSubstring("version mismatch"))
 
 	// This check should Pass
 	out = Calicoctl(true, "get", "node", "--context", "main")

--- a/tests/fv/namespace_option_test.go
+++ b/tests/fv/namespace_option_test.go
@@ -64,7 +64,12 @@ func TestMultiOption(t *testing.T) {
 	_, err = client.NetworkPolicies().Create(ctx, np, options.SetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
-	out, err := CalicoctlMayFail(false, "get", "ippool", "-A")
+	// Set Calico version in ClusterInformation
+	out, err := SetCalicoVersion(false)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(out).To(ContainSubstring("Calico version set to"))
+
+	out, err = CalicoctlMayFail(false, "get", "ippool", "-A")
 	Expect(err).To(HaveOccurred())
 	Expect(out).To(Equal("IPPool is not namespaced\n"))
 
@@ -78,4 +83,13 @@ func TestMultiOption(t *testing.T) {
 	out = Calicoctl(false, "get", "networkPolicy", "-a")
 	Expect(out).To(Equal("NAMESPACE   NAME      \nfirstns     policy1   \nsecondns    policy2   \n\n"))
 
+	// Clean up resources
+	_, err = client.IPPools().Delete(ctx, "ipam-test-v4", options.DeleteOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = client.NetworkPolicies().Delete(ctx, "firstns", "policy1", options.DeleteOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = client.NetworkPolicies().Delete(ctx, "secondns", "policy2", options.DeleteOptions{})
+	Expect(err).NotTo(HaveOccurred())
 }

--- a/tests/fv/utils/calicoctl.go
+++ b/tests/fv/utils/calicoctl.go
@@ -24,6 +24,22 @@ import (
 )
 
 var calicoctl = "/go/src/github.com/projectcalico/calicoctl/bin/calicoctl-linux-amd64"
+var version_helper = "/go/src/github.com/projectcalico/calicoctl/tests/fv/helper/bin/calico_version_helper"
+
+func getEnv(kdd bool) []string {
+	env := []string{"ETCD_ENDPOINTS=http://127.0.0.1:2379"}
+
+	if kdd {
+		val, ok := os.LookupEnv("KUBECONFIG")
+		if ok {
+			env = []string{"KUBECONFIG=" + val, "DATASTORE_TYPE=kubernetes"}
+		} else {
+			env = []string{"K8S_API_ENDPOINT=http://localhost:8080", "DATASTORE_TYPE=kubernetes"}
+		}
+	}
+
+	return env
+}
 
 func Calicoctl(kdd bool, args ...string) string {
 	out, err := CalicoctlMayFail(kdd, args...)
@@ -33,18 +49,25 @@ func Calicoctl(kdd bool, args ...string) string {
 
 func CalicoctlMayFail(kdd bool, args ...string) (string, error) {
 	cmd := exec.Command(calicoctl, args...)
-	cmd.Env = []string{"ETCD_ENDPOINTS=http://127.0.0.1:2379"}
-	if kdd {
-		val, ok := os.LookupEnv("KUBECONFIG")
-		if ok {
-			cmd.Env = []string{"KUBECONFIG=" + val, "DATASTORE_TYPE=kubernetes"}
-		} else {
-			cmd.Env = []string{"K8S_API_ENDPOINT=http://localhost:8080", "DATASTORE_TYPE=kubernetes"}
-		}
-	}
+	cmd.Env = getEnv(kdd)
 	out, err := cmd.CombinedOutput()
+
 	log.Infof("Run: calicoctl %v", strings.Join(args, " "))
 	log.Infof("Output:\n%v", string(out))
 	log.Infof("Error: %v", err)
+
 	return string(out), err
+}
+
+func SetCalicoVersion(kdd bool, args ...string) (string, error) {
+	// Set CalicoVersion in ClusterInformation
+	helperCmd := exec.Command(version_helper, args...)
+	helperCmd.Env = getEnv(kdd)
+	helperOut, helperErr := helperCmd.CombinedOutput()
+
+	log.Infof("Run: %s %s", version_helper, strings.Join(args, " "))
+	log.Infof("Output:\n%v", string(helperOut))
+	log.Infof("Error: %v", helperErr)
+
+	return string(helperOut), helperErr
 }

--- a/tests/st/manifests/crd.projectcalico.org_clusterinformations.yaml
+++ b/tests/st/manifests/crd.projectcalico.org_clusterinformations.yaml
@@ -1,0 +1,64 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: ClusterInformation
+    listKind: ClusterInformationList
+    plural: clusterinformations
+    singular: clusterinformation
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterInformation contains the cluster specific information.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterInformationSpec contains the values of describing
+              the cluster.
+            properties:
+              calicoVersion:
+                description: CalicoVersion is the version of Calico that the cluster
+                  is running
+                type: string
+              clusterGUID:
+                description: ClusterGUID is the GUID of the cluster
+                type: string
+              clusterType:
+                description: ClusterType describes the type of the cluster
+                type: string
+              datastoreReady:
+                description: DatastoreReady is used during significant datastore migrations
+                  to signal to components such as Felix that it should wait before
+                  accessing the datastore.
+                type: boolean
+              variant:
+                description: Variant declares which variant of Calico should be active.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Make `calicoctl` verify if the cluster version is the same as the client version before running. Add `--allow-version-mismatch` command line arg to override this verification if needed. The verification is also bypassed if the command being run is `datastore migrate import`, since the ClusterInformation will not be set in this case.

Add go utility app calico_version_helper, which is used to set the calico version in the ClusterInformation for test environments.

Add st coverage for the feature, and make multiple changes to st and fv tests to set the version so that the tests continue performing correctly.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Added calicoctl checks for version mismatch between itself and Calico in the cluster, with optional bypass argument '--allow-version-mismatch'.
```
