### PR TITLE
Skip version mismatch check when ClusterInformation does not exist

### DIFF
--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -211,6 +211,10 @@ Description:
 
 	ci, err := client.ClusterInformation().Get(ctx, "default", options.GetOptions{})
 	if err != nil {
+		if strings.Contains(err.Error(), "does not exist") {
+			// ClusterInformation does not exist, so skip version check.
+			return nil
+		}
 		return fmt.Errorf("Unable to get Cluster Information to verify version mismatch: %w", err)
 	}
 

--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	"github.com/docopt/docopt-go"
 
 	v3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/options"
 
 	"github.com/projectcalico/calicoctl/v3/calicoctl/commands/argutils"
@@ -211,7 +213,8 @@ Description:
 
 	ci, err := client.ClusterInformation().Get(ctx, "default", options.GetOptions{})
 	if err != nil {
-		if strings.Contains(err.Error(), "does not exist") {
+		var notFound cerrors.ErrorResourceDoesNotExist
+		if errors.As(err, &notFound) {
 			// ClusterInformation does not exist, so skip version check.
 			return nil
 		}


### PR DESCRIPTION
This is needed as a follow-up to #2353 , as many of Tigera's internal tests do not create any ClusterInformation.