### PR TITLE
Automated cherry pick of #2387: Skip version mismatch check for commands with no API

### DIFF
--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -206,7 +206,10 @@ Description:
 
 	client, err := clientmgr.NewClient(cf)
 	if err != nil {
-		return fmt.Errorf("Unable to create Calico API client to verify version mismatch: %w", err)
+		// If we can't connect to the cluster, skip the check. Either we're running a command that
+		// doesn't need API access, in which case the check doesn't need to be run, or we'll
+		// fail on the actual command.
+		return nil
 	}
 
 	ctx := context.Background()

--- a/tests/fv/multi_context_test.go
+++ b/tests/fv/multi_context_test.go
@@ -54,11 +54,6 @@ func TestMultiCluster(t *testing.T) {
 	Expect(err).To(HaveOccurred())
 	Expect(out).To(ContainSubstring("Failed"))
 
-	// This check will Fail a version mismatch cannot be verified for context "fake"
-	out, err = CalicoctlMayFail(true, "get", "node", "--context", "fake")
-	Expect(err).To(HaveOccurred())
-	Expect(out).To(ContainSubstring("version mismatch"))
-
 	// This check should Pass
 	out = Calicoctl(true, "get", "node", "--context", "main")
 	Expect(out).To(ContainSubstring("node4"))


### PR DESCRIPTION
Cherry pick of #2387 on master.

#2387: Skip version mismatch check for commands with no API