### PR TITLE
Updating apk-tools in Alpine-based images

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,6 +1,8 @@
 FROM arm64v8/alpine:3.10
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
+RUN apk --no-cache upgrade apk-tools
+
 ADD bin/calicoctl-linux-arm64 /calicoctl
 
 ENV CALICO_CTL_CONTAINER=TRUE

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -1,6 +1,8 @@
 FROM arm32v7/alpine:3.12
 MAINTAINER Marc Crébassa <aalaesar@gmail.com>
 
+RUN apk --no-cache upgrade apk-tools
+
 ADD bin/calicoctl-linux-armv7 /calicoctl
 
 ENV CALICO_CTL_CONTAINER=TRUE

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,6 +1,8 @@
 FROM ppc64le/alpine:3.10
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
+RUN apk --no-cache upgrade apk-tools
+
 ADD bin/calicoctl-linux-ppc64le /calicoctl
 
 ENV CALICO_CTL_CONTAINER=TRUE

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,6 +1,8 @@
 FROM s390x/alpine:3.10
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
+RUN apk --no-cache upgrade apk-tools
+
 ADD bin/calicoctl-linux-s390x /calicoctl
 
 ENV CALICO_CTL_CONTAINER=TRUE


### PR DESCRIPTION
Updating apk-tools in order to mitigate CVE-2021-36159

Fixes #2384

Signed-off by: Dave Hay <david_hay@uk.ibm.com>

## Description
For the `calicoctl` images that are based upon Alpine Linux, there's a requirement to update
`apk-tools` in order to mitigate [CVE-2021-36159](https://snyk.io/vuln/SNYK-ALPINE313-APKTOOLS-1533754)

The issue was identified, in an image built upon `s390x` via IBM Container Registry's Vulnerability Advisor tool.

I've manually built the `s390x` image, having previously built `calico/go-build`. I've also built `calicoctl` along with
the other Calico Node images, via our own Jenkins pipeline, again on/for `s390x`.

Having built `calicoctl` on `s390x`, I've deployed Calico Node to a K8s `1.21` cluster on the same platform, with
no apparent issues.

This PR affects four `calicoctl` images - for `s390x`, and also for IBM Power ( `ppc` ) and ARM
( 32-bit and 64-bit )

I've not tested the `ppc` and `arm` builds, but can, if needed, find a `ppc` box to test that build

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Updating apk-tools in Alpine-based images
```
