### PR TITLE
ARM64 dockerfile updates

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,8 +1,39 @@
-FROM arm64v8/alpine:3.10
-MAINTAINER Tom Denham <tom@projectcalico.org>
+# Copyright (c) 2020 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG QEMU_IMAGE=calico/go-build:v0.55
+FROM ${QEMU_IMAGE} as qemu
 
-RUN apk --no-cache upgrade apk-tools
+FROM --platform=linux/arm64 registry.access.redhat.com/ubi8/ubi-minimal:8.2 as ubi
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/
 
+RUN mkdir /licenses
+COPY LICENSE /licenses
+
+FROM scratch
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/
+
+ARG GIT_VERSION=unknown
+
+LABEL name="Calico CLI tool" \
+      vendor="Project Calico" \
+      version=$GIT_VERSION \
+      release="1" \
+      summary="Calico CLI tool" \
+      description="calicoctl(1) is a command line tool used to interface with the Calico datastore " \
+      maintainer="maintainers@projectcalico.org"
+
+COPY --from=ubi /licenses /licenses
 ADD bin/calicoctl-linux-arm64 /calicoctl
 
 ENV CALICO_CTL_CONTAINER=TRUE

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ Makefile.common.$(MAKE_BRANCH):
 
 include Makefile.common
 
+ifeq ($(ARCH),arm64)
+# Prevents docker from tagging the output image incorrectly as amd64.
+TARGET_PLATFORM=--platform=linux/arm64/v8
+endif
 ###############################################################################
 
 CALICOCTL_DIR=calicoctl
@@ -133,8 +137,8 @@ remote-deps: mod-download
 .PHONY: image $(CALICOCTL_IMAGE)
 image: $(CALICOCTL_IMAGE)
 $(CALICOCTL_IMAGE): $(CTL_CONTAINER_CREATED)
-$(CTL_CONTAINER_CREATED): Dockerfile.$(ARCH) bin/calicoctl-linux-$(ARCH)
-	docker build -t $(CALICOCTL_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
+$(CTL_CONTAINER_CREATED): register Dockerfile.$(ARCH) bin/calicoctl-linux-$(ARCH)
+	docker build -t $(CALICOCTL_IMAGE):latest-$(ARCH) $(TARGET_PLATFORM) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
 ifeq ($(ARCH),amd64)
 	docker tag $(CALICOCTL_IMAGE):latest-$(ARCH) $(CALICOCTL_IMAGE):latest
 endif


### PR DESCRIPTION
Update: Dockerfile.arm64 synced with `amd64`
Add: `TARGET_PLATFORM` in Makefile now forces docker to to tag the output with `arm64` architecture.


```release-note
None required
```
