### PR TITLE
Multiarch image adjustments

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -15,13 +15,14 @@ ARG QEMU_IMAGE=calico/go-build:v0.55
 FROM ${QEMU_IMAGE} as qemu
 
 FROM --platform=linux/arm64 registry.access.redhat.com/ubi8/ubi-minimal:8.2 as ubi
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/
 
 RUN mkdir /licenses
 COPY LICENSE /licenses
 
 FROM scratch
-COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/
 
 ARG GIT_VERSION=unknown
 

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -1,4 +1,11 @@
+ARG QEMU_IMAGE
+FROM --platform=linux/arm/v7 ${QEMU_IMAGE} as qemu
+
 FROM arm32v7/alpine:3.12
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin/
+
 MAINTAINER Marc Crébassa <aalaesar@gmail.com>
 
 RUN apk --no-cache upgrade apk-tools
@@ -7,6 +14,8 @@ ADD bin/calicoctl-linux-armv7 /calicoctl
 
 ENV CALICO_CTL_CONTAINER=TRUE
 ENV PATH=$PATH:/
+# Delete qemu binaries
+RUN rm /usr/bin/qemu-*
 
 WORKDIR /root
 ENTRYPOINT ["/calicoctl"]

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,5 +1,11 @@
+ARG QEMU_IMAGE
+FROM ${QEMU_IMAGE} as qemu
+
 FROM ppc64le/alpine:3.10
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
 MAINTAINER Tom Denham <tom@projectcalico.org>
+COPY --from=qemu /usr/bin/qemu-ppc64le-static /usr/bin/
 
 RUN apk --no-cache upgrade apk-tools
 
@@ -7,6 +13,9 @@ ADD bin/calicoctl-linux-ppc64le /calicoctl
 
 ENV CALICO_CTL_CONTAINER=TRUE
 ENV PATH=$PATH:/
+
+# Delete qemu binaries
+RUN rm /usr/bin/qemu-*
 
 WORKDIR /root
 ENTRYPOINT ["/calicoctl"]

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,4 +1,12 @@
+ARG QEMU_IMAGE
+# Copying qemu binary files from amd64 container.
+# latest `go-build` containers got no candidate for `s390x` architecture.
+FROM --platform=linux/amd64 ${QEMU_IMAGE} as qemu
+
 FROM s390x/alpine:3.10
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+COPY --from=qemu /usr/bin/qemu-s390x-static /usr/bin/
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
 
 RUN apk --no-cache upgrade apk-tools
@@ -7,6 +15,8 @@ ADD bin/calicoctl-linux-s390x /calicoctl
 
 ENV CALICO_CTL_CONTAINER=TRUE
 ENV PATH=$PATH:/
+
+RUN rm /usr/bin/qemu-*
 
 WORKDIR /root
 ENTRYPOINT ["/calicoctl"]

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,6 @@ Makefile.common.$(MAKE_BRANCH):
 
 include Makefile.common
 
-ifeq ($(ARCH),arm64)
-# Prevents docker from tagging the output image incorrectly as amd64.
-TARGET_PLATFORM=--platform=linux/arm64/v8
-endif
 ###############################################################################
 
 CALICOCTL_DIR=calicoctl
@@ -137,8 +133,8 @@ remote-deps: mod-download
 .PHONY: image $(CALICOCTL_IMAGE)
 image: $(CALICOCTL_IMAGE)
 $(CALICOCTL_IMAGE): $(CTL_CONTAINER_CREATED)
-$(CTL_CONTAINER_CREATED): register Dockerfile.$(ARCH) bin/calicoctl-linux-$(ARCH)
-	docker build -t $(CALICOCTL_IMAGE):latest-$(ARCH) $(TARGET_PLATFORM) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
+$(CTL_CONTAINER_CREATED): Dockerfile.$(ARCH) bin/calicoctl-linux-$(ARCH) register
+	docker buildx build --pull -t $(CALICOCTL_IMAGE):latest-$(ARCH) --platform=linux/$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) . --load
 ifeq ($(ARCH),amd64)
 	docker tag $(CALICOCTL_IMAGE):latest-$(ARCH) $(CALICOCTL_IMAGE):latest
 endif


### PR DESCRIPTION
Fix: This PR updates all non `amd64` dockerfiles for a multiarch release.

```release-note
None required
```
