### PR TITLE
Updated calicoctl RHEL UBI image to 8.5

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2 as ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5 as ubi
 
 RUN mkdir /licenses
 COPY LICENSE /licenses

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -14,7 +14,7 @@
 ARG QEMU_IMAGE=calico/go-build:v0.55
 FROM ${QEMU_IMAGE} as qemu
 
-FROM --platform=linux/arm64 registry.access.redhat.com/ubi8/ubi-minimal:8.2 as ubi
+FROM --platform=linux/arm64 registry.access.redhat.com/ubi8/ubi-minimal:8.5 as ubi
 # Enable non-native builds of this image on an amd64 hosts.
 # This must be the first RUN command in this file!
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/


### PR DESCRIPTION

## Description
Update RHEL UBI image from 8.2 to 8.5.

Fixes: #2460 

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
